### PR TITLE
feat: add idp_ids() to Authenticator trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ local
 .DS_Store
 .idea/
 Cargo.lock
-
+.claude
 .vscode
 
 # Created by https://www.toptal.com/developers/gitignore/api/rust,rust-analyzer,visualstudiocode

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -23,9 +23,45 @@ where
     /// Returns an id that uniquely identifies the `IdP` this authenticator is for.
     fn idp_id(&self) -> Option<&String>;
 
-    /// Returns the idp IDs of this authenticator.
-    /// For a single authenticator, this returns a one-element vec containing [`Self::idp_id()`].
-    /// For a chained authenticator, this returns the idp IDs of all children.
+    /// Collects the IdP identifier(s) associated with this authenticator.
+    
+    ///
+    
+    /// By default this yields a single-element vector containing the result of `self.idp_id()`
+    
+    /// (converted to a `&str`) for a standalone authenticator. Implementations that represent
+    
+    /// a chain of authenticators should return one element per child authenticator in chain order.
+    
+    ///
+    
+    /// # Returns
+    
+    ///
+    
+    /// A `Vec<Option<&str>>` where each element is the IdP identifier for one authenticator in the chain,
+    
+    /// or `None` when an authenticator does not have an IdP identifier.
+    
+    ///
+    
+    /// # Examples
+    
+    ///
+    
+    /// ```
+    
+    /// // Standalone authenticator with an idp_id of "example"
+    
+    /// struct A; impl A { fn idp_id(&self) -> Option<String> { Some("example".to_string()) } }
+    
+    /// impl A { fn idp_ids(&self) -> Vec<Option<&str>> { vec![self.idp_id().map(String::as_str)] } }
+    
+    /// let a = A;
+    
+    /// assert_eq!(a.idp_ids(), vec![Some("example")]);
+    
+    /// ```
     fn idp_ids(&self) -> Vec<Option<&str>> {
         vec![self.idp_id().map(String::as_str)]
     }

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -24,43 +24,24 @@ where
     fn idp_id(&self) -> Option<&String>;
 
     /// Collects the IdP identifier(s) associated with this authenticator.
-    
     ///
-    
     /// By default this yields a single-element vector containing the result of `self.idp_id()`
-    
     /// (converted to a `&str`) for a standalone authenticator. Implementations that represent
-    
     /// a chain of authenticators should return one element per child authenticator in chain order.
-    
     ///
-    
     /// # Returns
-    
     ///
-    
     /// A `Vec<Option<&str>>` where each element is the IdP identifier for one authenticator in the chain,
-    
     /// or `None` when an authenticator does not have an IdP identifier.
-    
     ///
-    
     /// # Examples
-    
     ///
-    
     /// ```
-    
     /// // Standalone authenticator with an idp_id of "example"
-    
     /// struct A; impl A { fn idp_id(&self) -> Option<String> { Some("example".to_string()) } }
-    
     /// impl A { fn idp_ids(&self) -> Vec<Option<&str>> { vec![self.idp_id().map(String::as_str)] } }
-    
     /// let a = A;
-    
     /// assert_eq!(a.idp_ids(), vec![Some("example")]);
-    
     /// ```
     fn idp_ids(&self) -> Vec<Option<&str>> {
         vec![self.idp_id().map(String::as_str)]

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -22,6 +22,13 @@ where
 
     /// Returns an id that uniquely identifies the `IdP` this authenticator is for.
     fn idp_id(&self) -> Option<&String>;
+
+    /// Returns the idp IDs of this authenticator.
+    /// For a single authenticator, this returns a one-element vec containing [`Self::idp_id()`].
+    /// For a chained authenticator, this returns the idp IDs of all children.
+    fn idp_ids(&self) -> Vec<Option<&str>> {
+        vec![self.idp_id().map(String::as_str)]
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, TypedBuilder)]

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -33,16 +33,6 @@ where
     ///
     /// A `Vec<Option<&str>>` where each element is the IdP identifier for one authenticator in the chain,
     /// or `None` when an authenticator does not have an IdP identifier.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// // Standalone authenticator with an idp_id of "example"
-    /// struct A; impl A { fn idp_id(&self) -> Option<String> { Some("example".to_string()) } }
-    /// impl A { fn idp_ids(&self) -> Vec<Option<&str>> { vec![self.idp_id().map(String::as_str)] } }
-    /// let a = A;
-    /// assert_eq!(a.idp_ids(), vec![Some("example")]);
-    /// ```
     fn idp_ids(&self) -> Vec<Option<&str>> {
         vec![self.idp_id().map(String::as_str)]
     }

--- a/crates/limes/src/chain.rs
+++ b/crates/limes/src/chain.rs
@@ -61,6 +61,13 @@ where
         self.authenticators[0].idp_id()
     }
 
+    fn idp_ids(&self) -> Vec<Option<&str>> {
+        self.authenticators
+            .iter()
+            .map(|a| a.idp_id().map(String::as_str))
+            .collect()
+    }
+
     fn can_handle_token(&self, token: &str, introspection_result: &IntrospectionResult) -> bool {
         self.authenticators
             .iter()

--- a/crates/limes/src/chain.rs
+++ b/crates/limes/src/chain.rs
@@ -57,10 +57,29 @@ where
         Err(Error::NoAuthenticatorCanHandleToken)
     }
 
+    /// Get the identity provider ID from the first authenticator in the chain, if present.
+    ///
+    /// Returns the first authenticator's `idp_id()` value as `Option<&String>`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the chain contains no authenticators.
     fn idp_id(&self) -> Option<&String> {
         self.authenticators[0].idp_id()
     }
 
+    /// Returns a vector of each contained authenticator's `idp_id` as `Option<&str>`.
+    ///
+    /// The returned vector preserves the order of authenticators; each element is
+    /// either `Some(&str)` referencing the authenticator's `String` id, or `None`
+    /// if that authenticator has no id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // Given an existing `chain: AuthenticatorChain<_>`, obtain all idp ids:
+    /// let ids: Vec<Option<&str>> = chain.idp_ids();
+    /// ```
     fn idp_ids(&self) -> Vec<Option<&str>> {
         self.authenticators
             .iter()
@@ -68,6 +87,18 @@ where
             .collect()
     }
 
+    /// Returns whether any contained authenticator can handle the given token.
+    ///
+    /// Checks each authenticator in the chain with the provided introspection result and
+    /// returns `true` as soon as one reports it can handle the token.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// // Assuming `chain` is an AuthenticatorChain and `introspect` is an IntrospectionResult:
+    /// let token = "eyJ...";
+    /// let can_handle = chain.can_handle_token(token, &introspect);
+    /// ```
     fn can_handle_token(&self, token: &str, introspection_result: &IntrospectionResult) -> bool {
         self.authenticators
             .iter()

--- a/crates/limes/src/chain.rs
+++ b/crates/limes/src/chain.rs
@@ -83,7 +83,7 @@ where
     fn idp_ids(&self) -> Vec<Option<&str>> {
         self.authenticators
             .iter()
-            .map(|a| a.idp_id().map(String::as_str))
+            .flat_map(Authenticator::idp_ids)
             .collect()
     }
 

--- a/crates/limes/src/chain.rs
+++ b/crates/limes/src/chain.rs
@@ -73,13 +73,6 @@ where
     /// The returned vector preserves the order of authenticators; each element is
     /// either `Some(&str)` referencing the authenticator's `String` id, or `None`
     /// if that authenticator has no id.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// // Given an existing `chain: AuthenticatorChain<_>`, obtain all idp ids:
-    /// let ids: Vec<Option<&str>> = chain.idp_ids();
-    /// ```
     fn idp_ids(&self) -> Vec<Option<&str>> {
         self.authenticators
             .iter()
@@ -91,14 +84,6 @@ where
     ///
     /// Checks each authenticator in the chain with the provided introspection result and
     /// returns `true` as soon as one reports it can handle the token.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,no_run
-    /// // Assuming `chain` is an AuthenticatorChain and `introspect` is an IntrospectionResult:
-    /// let token = "eyJ...";
-    /// let can_handle = chain.can_handle_token(token, &introspect);
-    /// ```
     fn can_handle_token(&self, token: &str, introspection_result: &IntrospectionResult) -> bool {
         self.authenticators
             .iter()

--- a/crates/limes/src/chain.rs
+++ b/crates/limes/src/chain.rs
@@ -45,6 +45,11 @@ impl<T> Authenticator for AuthenticatorChain<T>
 where
     T: Authenticator,
 {
+    /// Authenticate a token using the first authenticator in the chain that can handle it.
+    ///
+    /// # Errors
+    /// - No authenticator in the chain can handle the token.
+    /// - The matching authenticator rejects the token.
     async fn authenticate(&self, token: &str) -> Result<Authentication> {
         let introspect_result = introspect(token);
 
@@ -57,22 +62,13 @@ where
         Err(Error::NoAuthenticatorCanHandleToken)
     }
 
-    /// Get the identity provider ID from the first authenticator in the chain, if present.
-    ///
-    /// Returns the first authenticator's `idp_id()` value as `Option<&String>`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the chain contains no authenticators.
+    /// Returns the `idp_id` of the first authenticator in the chain, or `None` if the chain is empty.
     fn idp_id(&self) -> Option<&String> {
-        self.authenticators[0].idp_id()
+        self.authenticators.first().and_then(Authenticator::idp_id)
     }
 
-    /// Returns a vector of each contained authenticator's `idp_id` as `Option<&str>`.
-    ///
-    /// The returned vector preserves the order of authenticators; each element is
-    /// either `Some(&str)` referencing the authenticator's `String` id, or `None`
-    /// if that authenticator has no id.
+    /// Returns the `idp_id` of every authenticator in the chain, in order.
+    /// Each element is `None` for authenticators that have no `idp_id` set.
     fn idp_ids(&self) -> Vec<Option<&str>> {
         self.authenticators
             .iter()
@@ -80,10 +76,7 @@ where
             .collect()
     }
 
-    /// Returns whether any contained authenticator can handle the given token.
-    ///
-    /// Checks each authenticator in the chain with the provided introspection result and
-    /// returns `true` as soon as one reports it can handle the token.
+    /// Returns `true` if any authenticator in the chain can handle the token.
     fn can_handle_token(&self, token: &str, introspection_result: &IntrospectionResult) -> bool {
         self.authenticators
             .iter()

--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -635,7 +635,7 @@ mod test {
         let payload = extract_authentication(
             Some("idp"),
             token_data,
-            &vec!["oid".to_string(), "sub".to_string()],
+            &["oid".to_string(), "sub".to_string()],
             None,
         )
         .unwrap();
@@ -695,8 +695,7 @@ mod test {
         };
 
         let payload =
-            extract_authentication(Some("idp"), token_data, &vec!["oid".to_string()], None)
-                .unwrap();
+            extract_authentication(Some("idp"), token_data, &["oid".to_string()], None).unwrap();
 
         let subject = Subject::new(Some("idp".to_string()), "user-oid".to_string());
 
@@ -760,8 +759,7 @@ mod test {
         };
 
         let payload =
-            extract_authentication(Some("idp"), token_data, &vec!["oid".to_string()], None)
-                .unwrap();
+            extract_authentication(Some("idp"), token_data, &["oid".to_string()], None).unwrap();
 
         let subject = Subject::new(
             Some("idp".to_string()),
@@ -786,7 +784,7 @@ mod test {
             "roles": ["admin", "user", "editor"]
         });
 
-        let roles = get_roles(&claims, Some(&vec!["roles".to_string()]));
+        let roles = get_roles(&claims, Some(&["roles".to_string()]));
         assert_eq!(
             roles,
             Some(vec![
@@ -809,7 +807,7 @@ mod test {
 
         let roles = get_roles(
             &claims,
-            Some(&vec!["resource_access.account.roles".to_string()]),
+            Some(&["resource_access.account.roles".to_string()]),
         );
         assert_eq!(
             roles,
@@ -836,7 +834,7 @@ mod test {
         // Should return first match
         let roles = get_roles(
             &claims,
-            Some(&vec![
+            Some(&[
                 "realm_access.roles".to_string(),
                 "resource_access.account.roles".to_string(),
             ]),
@@ -857,7 +855,7 @@ mod test {
         // First path doesn't exist, should fall back to second
         let roles = get_roles(
             &claims,
-            Some(&vec![
+            Some(&[
                 "realm_access.roles".to_string(),
                 "resource_access.account.roles".to_string(),
             ]),
@@ -871,7 +869,7 @@ mod test {
             "other_field": "value"
         });
 
-        let roles = get_roles(&claims, Some(&vec!["roles".to_string()]));
+        let roles = get_roles(&claims, Some(&["roles".to_string()]));
         assert_eq!(roles, None);
     }
 
@@ -881,7 +879,7 @@ mod test {
             "role": "admin"
         });
 
-        let roles = get_roles(&claims, Some(&vec!["role".to_string()]));
+        let roles = get_roles(&claims, Some(&["role".to_string()]));
         assert_eq!(roles, Some(vec!["admin".to_string()]));
     }
 
@@ -893,7 +891,7 @@ mod test {
         });
 
         // Should return None, not Some(vec![]), because no valid strings found
-        let roles = get_roles(&claims, Some(&vec!["roles".to_string()]));
+        let roles = get_roles(&claims, Some(&["roles".to_string()]));
         assert_eq!(roles, None);
     }
 
@@ -905,7 +903,7 @@ mod test {
         });
 
         // Should return None, not Some(vec![]), treating empty like non-existent
-        let roles = get_roles(&claims, Some(&vec!["roles".to_string()]));
+        let roles = get_roles(&claims, Some(&["roles".to_string()]));
         assert_eq!(roles, None);
     }
 
@@ -917,7 +915,7 @@ mod test {
         });
 
         // Should extract only the string values, filtering out non-strings
-        let roles = get_roles(&claims, Some(&vec!["roles".to_string()]));
+        let roles = get_roles(&claims, Some(&["roles".to_string()]));
         assert_eq!(
             roles,
             Some(vec![
@@ -939,10 +937,7 @@ mod test {
         // Should skip first path (no valid strings) and use second path
         let roles = get_roles(
             &claims,
-            Some(&vec![
-                "invalid_roles".to_string(),
-                "valid_roles".to_string(),
-            ]),
+            Some(&["invalid_roles".to_string(), "valid_roles".to_string()]),
         );
         assert_eq!(roles, Some(vec!["user".to_string(), "viewer".to_string()]));
     }
@@ -994,13 +989,9 @@ mod test {
             claims: claims.clone(),
         };
 
-        let payload = extract_authentication(
-            Some("idp"),
-            token_data.clone(),
-            &vec!["sub".to_string()],
-            None,
-        )
-        .unwrap();
+        let payload =
+            extract_authentication(Some("idp"), token_data.clone(), &["sub".to_string()], None)
+                .unwrap();
 
         let subject = Subject::new(
             Some("idp".to_string()),
@@ -1022,8 +1013,8 @@ mod test {
         let payload_with_roles = extract_authentication(
             Some("idp"),
             token_data,
-            &vec!["sub".to_string()],
-            Some(&vec!["realm_access.roles".to_string()]),
+            &["sub".to_string()],
+            Some(&["realm_access.roles".to_string()]),
         )
         .unwrap();
 
@@ -1097,13 +1088,9 @@ mod test {
             claims: claims.clone(),
         };
 
-        let payload = extract_authentication(
-            Some("idp"),
-            token_data.clone(),
-            &vec!["sub".to_string()],
-            None,
-        )
-        .unwrap();
+        let payload =
+            extract_authentication(Some("idp"), token_data.clone(), &["sub".to_string()], None)
+                .unwrap();
 
         let subject = Subject::new(
             Some("idp".to_string()),
@@ -1125,8 +1112,8 @@ mod test {
         let payload_with_roles = extract_authentication(
             Some("idp"),
             token_data,
-            &vec!["sub".to_string()],
-            Some(&vec!["resource_access.account.roles".to_string()]),
+            &["sub".to_string()],
+            Some(&["resource_access.account.roles".to_string()]),
         )
         .unwrap();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an ignore rule for a local ".claude" configuration file.

* **Refactor**
  * Enhanced authenticator API to expose multiple identity-provider identifiers and streamlined token handling in authenticator chains for clearer multi-provider behavior.

* **Tests**
  * Updated unit tests to use slice-style inputs for claim paths and adjusted role extraction assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->