### PR TITLE
feat: expose token audiences on Authentication

### DIFF
--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -130,6 +130,6 @@ impl Authentication {
 
     #[must_use]
     pub fn idp_id(&self) -> Option<&str> {
-        self.subject().idp_id().map(|x| x.as_str())
+        self.subject().idp_id().map(std::string::String::as_str)
     }
 }

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -131,7 +131,7 @@ impl Authentication {
     #[must_use]
     /// Get the IdP identifier of the subject, if present.
     /// This is a convenience accessor that maps the `Option<&String>` returned by
-    /// the [`Authenticator`] trait's `idp_id` to `Option<&str>`.
+    /// [`Subject::idp_id`] to `Option<&str>`.
     pub fn idp_id(&self) -> Option<&str> {
         self.subject().idp_id().map(std::string::String::as_str)
     }

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -1,6 +1,7 @@
 use crate::{Subject, error::Result, introspect::IntrospectionResult};
 use core::{future::Future, marker::Sync};
 pub(crate) use jsonwebtoken::Header;
+use std::collections::HashSet;
 use std::fmt::Debug;
 use typed_builder::TypedBuilder;
 
@@ -62,6 +63,9 @@ pub struct Authentication {
     /// Roles of the user extracted from the token if any.
     #[builder(default)]
     roles: Option<Vec<String>>,
+    /// Audiences of the token.
+    #[builder(default)]
+    audiences: HashSet<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
@@ -116,5 +120,16 @@ impl Authentication {
     #[must_use]
     pub fn roles(&self) -> Option<&[String]> {
         self.roles.as_deref()
+    }
+
+    #[must_use]
+    /// Get the audiences of the token.
+    pub fn audiences(&self) -> &HashSet<String> {
+        &self.audiences
+    }
+
+    #[must_use]
+    pub fn idp_id(&self) -> Option<&str> {
+        self.subject().idp_id().map(|x| x.as_str())
     }
 }

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -129,6 +129,9 @@ impl Authentication {
     }
 
     #[must_use]
+    /// Get the IdP identifier of the subject, if present.
+    /// This is a convenience accessor that maps the `Option<&String>` returned by
+    /// the [`Authenticator`] trait's `idp_id` to `Option<&str>`.
     pub fn idp_id(&self) -> Option<&str> {
         self.subject().idp_id().map(std::string::String::as_str)
     }

--- a/crates/limes/src/introspect.rs
+++ b/crates/limes/src/introspect.rs
@@ -85,7 +85,7 @@ impl Audience {
 /// Handles both single-string (`"aud": "app"`) and array (`"aud": ["app1", "app2"]`) forms.
 pub(crate) fn parse_aud(value: Option<&serde_json::Value>) -> HashSet<String> {
     value
-        .and_then(|v| serde_json::from_value::<Audience>(v.clone()).ok())
+        .and_then(|v| Audience::deserialize(v).ok())
         .map(Audience::into_set)
         .unwrap_or_default()
 }

--- a/crates/limes/src/introspect.rs
+++ b/crates/limes/src/introspect.rs
@@ -148,7 +148,7 @@ mod tests {
                 assert!(aud.contains("account"));
                 assert!(aud.contains("lakekeeper"));
             }
-            _ => panic!("Unexpected result: {result:?}"),
+            IntrospectionResult::Unknown => panic!("Unexpected result: {result:?}"),
         }
     }
 

--- a/crates/limes/src/introspect.rs
+++ b/crates/limes/src/introspect.rs
@@ -81,6 +81,15 @@ impl Audience {
     }
 }
 
+/// Parse the `aud` claim from a JSON value into a `HashSet<String>`.
+/// Handles both single-string (`"aud": "app"`) and array (`"aud": ["app1", "app2"]`) forms.
+pub(crate) fn parse_aud(value: Option<&serde_json::Value>) -> HashSet<String> {
+    value
+        .and_then(|v| serde_json::from_value::<Audience>(v.clone()).ok())
+        .map(Audience::into_set)
+        .unwrap_or_default()
+}
+
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum Issuer {
@@ -101,6 +110,29 @@ impl Issuer {
 mod tests {
     use super::*;
     use tracing_test::traced_test;
+
+    #[test]
+    fn test_parse_aud_single_string() {
+        let aud = serde_json::json!("my-app");
+        let parsed = parse_aud(Some(&aud));
+        assert_eq!(parsed, HashSet::from(["my-app".to_string()]));
+    }
+
+    #[test]
+    fn test_parse_aud_array() {
+        let aud = serde_json::json!(["my-app", "other-app"]);
+        let parsed = parse_aud(Some(&aud));
+        assert_eq!(
+            parsed,
+            HashSet::from(["my-app".to_string(), "other-app".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_parse_aud_none() {
+        let parsed = parse_aud(None);
+        assert_eq!(parsed, HashSet::new());
+    }
 
     #[test]
     #[traced_test]

--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -17,6 +17,7 @@ const SUBJECT_CLAIM: &str = "sub";
 const IDTYP_CLAIM: &str = "idtyp";
 const APP_DISPLAYNAME_CLAIM: &str = "app_displayname";
 const NAME_CLAIM: &str = "name";
+const AUD_CLAIM: &str = "aud";
 
 #[derive(Clone)]
 /// Validate JWT tokens using JWKS keys fetched from a remote server.
@@ -398,6 +399,8 @@ fn extract_authentication(
 
     let roles = get_roles(&claims, role_claims);
 
+    let audiences = crate::introspect::parse_aud(claims.get(AUD_CLAIM));
+
     Ok(Authentication::builder()
         .token_header(Some(token_data.header))
         .claims(claims.clone())
@@ -406,6 +409,7 @@ fn extract_authentication(
         .subject(subject)
         .principal_type(principal_type)
         .roles(roles)
+        .audiences(audiences)
         .build())
 }
 
@@ -577,6 +581,7 @@ fn value_as_string(value: &serde_json::Value) -> Option<String> {
 mod test {
     use super::*;
     use pretty_assertions::assert_eq;
+    use std::collections::HashSet;
 
     #[test]
     fn test_parse_scope_multi() {
@@ -651,6 +656,7 @@ mod test {
             .email(None)
             .subject(subject)
             .principal_type(Some(PrincipalType::Application))
+            .audiences(HashSet::from(["00000003-0000-0000-c000-000000000000".to_string()]))
             .build();
 
         assert_eq!(payload, expected_payload);
@@ -706,6 +712,7 @@ mod test {
             .email(Some("peter@example.com".to_string()))
             .subject(subject)
             .principal_type(Some(PrincipalType::Human))
+            .audiences(HashSet::from(["api://xyz".to_string()]))
             .build();
 
         assert_eq!(payload, expected_payload);
@@ -773,6 +780,7 @@ mod test {
             .email(Some("jack@example.com".to_string()))
             .subject(subject)
             .principal_type(Some(PrincipalType::Human))
+            .audiences(HashSet::from(["00000003-0000-0000-c000-000000000000".to_string()]))
             .build();
 
         assert_eq!(payload, expected_payload);
@@ -1005,6 +1013,7 @@ mod test {
             .email(Some("peter@example.com".to_string()))
             .subject(subject.clone())
             .principal_type(Some(PrincipalType::Human))
+            .audiences(HashSet::from(["account".to_string()]))
             .build();
 
         assert_eq!(payload, expected_payload);
@@ -1030,6 +1039,7 @@ mod test {
                 "uma_authorization".to_string(),
                 "default-roles-iceberg".to_string(),
             ]))
+            .audiences(HashSet::from(["account".to_string()]))
             .build();
 
         assert_eq!(payload_with_roles, expected_with_roles);
@@ -1104,6 +1114,10 @@ mod test {
             .email(None)
             .subject(subject.clone())
             .principal_type(Some(PrincipalType::Application))
+            .audiences(HashSet::from([
+                "iceberg-catalog".to_string(),
+                "account".to_string(),
+            ]))
             .build();
 
         assert_eq!(payload, expected_payload);
@@ -1128,6 +1142,10 @@ mod test {
                 "manage-account".to_string(),
                 "manage-account-links".to_string(),
                 "view-profile".to_string(),
+            ]))
+            .audiences(HashSet::from([
+                "iceberg-catalog".to_string(),
+                "account".to_string(),
             ]))
             .build();
 

--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -1155,4 +1155,29 @@ mod test {
 
         assert_eq!(payload_with_roles, expected_with_roles);
     }
+
+    #[test]
+    fn test_payload_missing_aud_claim_yields_empty_audiences() {
+        // A token with no "aud" field at all.  parse_aud() receives None and must
+        // fall through its unwrap_or_default() branch, returning an empty HashSet
+        // without panicking.
+        let claims = serde_json::json!({
+            "sub": "some-subject",
+            "iss": "https://example.com/",
+            "iat": 1_730_048_619,
+            "exp": 1_730_052_519,
+            "name": "Test User"
+        });
+
+        let token_header = jsonwebtoken::Header::new(Algorithm::RS256);
+        let token_data = jsonwebtoken::TokenData {
+            header: token_header.clone(),
+            claims: claims.clone(),
+        };
+
+        let payload =
+            extract_authentication(Some("idp"), token_data, &["sub".to_string()], None).unwrap();
+
+        assert_eq!(payload.audiences(), &HashSet::new());
+    }
 }

--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -656,7 +656,9 @@ mod test {
             .email(None)
             .subject(subject)
             .principal_type(Some(PrincipalType::Application))
-            .audiences(HashSet::from(["00000003-0000-0000-c000-000000000000".to_string()]))
+            .audiences(HashSet::from([
+                "00000003-0000-0000-c000-000000000000".to_string()
+            ]))
             .build();
 
         assert_eq!(payload, expected_payload);
@@ -780,7 +782,9 @@ mod test {
             .email(Some("jack@example.com".to_string()))
             .subject(subject)
             .principal_type(Some(PrincipalType::Human))
-            .audiences(HashSet::from(["00000003-0000-0000-c000-000000000000".to_string()]))
+            .audiences(HashSet::from([
+                "00000003-0000-0000-c000-000000000000".to_string()
+            ]))
             .build();
 
         assert_eq!(payload, expected_payload);

--- a/crates/limes/src/kubernetes.rs
+++ b/crates/limes/src/kubernetes.rs
@@ -179,7 +179,8 @@ fn parse_review_status(
         .ok_or_else(|| Error::unauthenticated("Kubernetes TokenReview returned no status"))?;
 
     // Validate Audience
-    validate_audience(audiences, &token_review.audiences.unwrap_or_default())?;
+    let actual_audiences = token_review.audiences.unwrap_or_default();
+    validate_audience(audiences, &actual_audiences)?;
 
     // Raise k8s error
     if let Some(error) = token_review.error {
@@ -210,6 +211,7 @@ fn parse_review_status(
         .principal_type(Some(crate::PrincipalType::Application))
         .token_header(None)
         .claims(claims)
+        .audiences(actual_audiences.into_iter().collect())
         .build())
 }
 

--- a/crates/limes/src/kubernetes.rs
+++ b/crates/limes/src/kubernetes.rs
@@ -244,6 +244,7 @@ fn validate_audience(expected: &[String], received: &[String]) -> Result<()> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::collections::HashSet;
 
     #[test]
     fn test_parse_review_status() {
@@ -307,6 +308,10 @@ mod test {
         assert_eq!(
             payload.subject().idp_id(),
             Some("my-k8s-cluster".to_string()).as_ref()
+        );
+        assert_eq!(
+            payload.audiences(),
+            &HashSet::from(["https://kubernetes.default.svc".to_string()])
         );
     }
 }


### PR DESCRIPTION
For next minor release we should clean up: https://github.com/vakamo-labs/limes-rs/issues/58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication tokens now capture and expose audience claims (single, multiple, or missing) and include a convenient IdP identifier accessor; audience values are propagated through validation and extraction paths.

* **Tests**
  * Added tests for audience parsing (string/array/none) and updated end-to-end authentication tests to verify audience handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->