### PR TITLE
feat!: introspect once per request, bump deps (#58)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,10 @@ jobs:
       - name: "doc --lib --all-features"
         run: |
           cargo doc --lib --no-deps --all-features --document-private-items
+        env:
+          # `cargo doc` does not build dev-dependencies, and the library no longer pins a
+          # k8s-openapi version, so select one here for the docs build.
+          K8S_OPENAPI_ENABLED_VERSION: "1.32"
         # env:
         #   RUSTFLAGS: --cfg docsrs
         #   RUSTDOCFLAGS: --cfg docsrs -Dwarnings

--- a/crates/limes/Cargo.toml
+++ b/crates/limes/Cargo.toml
@@ -18,9 +18,9 @@ default = ["rustls-tls", "jwks", "aws-lc-rs"]
 kubernetes = ["kube", "k8s-openapi"]
 rustls-tls = [
     "kube?/rustls-tls",
-    "jwks_client_rs?/rustls-tls",
-    "reqwest/rustls-tls",
-    "reqwest/rustls-tls-native-roots",
+    "jwks_client_rs?/rustls",
+    "reqwest/rustls",
+    "reqwest/rustls-native-certs",
 ]
 aws-lc-rs = ["kube?/aws-lc-rs"]
 ring = ["kube?/ring"]
@@ -31,14 +31,14 @@ valuable = ["dep:valuable"]
 [dependencies]
 axum = { version = "0.8", optional = true }
 axum-extra = { version = "0.12", optional = true, features = ["typed-header"] }
-jsonwebtoken = { version = "10.2", features = ["aws_lc_rs"] }
-jwks_client_rs = { version = "0.5.2", optional = true, default-features = false }
-k8s-openapi = { version = "0.26", features = ["v1_32"], optional = true }
-kube = { version = "2.0", default-features = false, features = [
+jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"] }
+jwks_client_rs = { version = "0.6", optional = true, default-features = false }
+k8s-openapi = { version = "0.28", features = ["v1_32"], optional = true }
+kube = { version = "4.0", default-features = false, features = [
     "client",
 ], optional = true }
 once_cell = "1.20"
-reqwest = { version = "0.12", default-features = false, features = ["json"] }
+reqwest = { version = "0.13", default-features = false, features = ["json"] }
 serde = { version = "1.0" }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 thiserror = { version = "2.0" }

--- a/crates/limes/Cargo.toml
+++ b/crates/limes/Cargo.toml
@@ -33,7 +33,10 @@ axum = { version = "0.8", optional = true }
 axum-extra = { version = "0.12", optional = true, features = ["typed-header"] }
 jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"] }
 jwks_client_rs = { version = "0.6", optional = true, default-features = false }
-k8s-openapi = { version = "0.28", features = ["v1_32"], optional = true }
+# No version feature here: per k8s-openapi's guidance a library must let the final
+# binary crate choose the Kubernetes version. The version is selected in dev-dependencies
+# (for our own tests) and by consumers (see the `kubernetes` feature docs).
+k8s-openapi = { version = "0.28", optional = true }
 kube = { version = "4.0", default-features = false, features = [
     "client",
 ], optional = true }
@@ -50,6 +53,8 @@ valuable = { version = "0.1.1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 axum = { version = "0.8" }
+# Select a Kubernetes version for the crate's own tests only (not forced on consumers).
+k8s-openapi = { version = "0.28", features = ["v1_32"] }
 pretty_assertions = "1.4"
 tokio = { version = "1.43", features = ["rt-multi-thread"] }
 tracing-test = "0.2.5"

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -12,9 +12,19 @@ where
     /// Authenticate a token. This must validate the tokens signature and claims.
     /// For opaque tokens, handlers may connect to the `IdP` to validate the token.
     ///
+    /// The `introspection` is the result of [`introspect`](`crate::introspect::introspect`)
+    /// for `token`. It is computed once before routing (e.g. in
+    /// [`AuthenticatorChain`](`crate::AuthenticatorChain`) and the axum middleware) and passed
+    /// in so implementations can reuse the already-decoded header and claims instead of
+    /// decoding the token a second time.
+    ///
     /// # Errors
     /// - Token is not valid.
-    fn authenticate(&self, token: &str) -> impl Future<Output = Result<Authentication>> + Send;
+    fn authenticate(
+        &self,
+        token: &str,
+        introspection: &IntrospectionResult,
+    ) -> impl Future<Output = Result<Authentication>> + Send;
 
     /// Check if the authenticator can handle the token.
     /// This is used in the [`AuthenticatorChain`](`crate::AuthenticatorChain`) to determine which authenticator to use.

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -12,11 +12,12 @@ where
     /// Authenticate a token. This must validate the tokens signature and claims.
     /// For opaque tokens, handlers may connect to the `IdP` to validate the token.
     ///
-    /// The `introspection` is the result of [`introspect`](`crate::introspect::introspect`)
-    /// for `token`. It is computed once before routing (e.g. in
-    /// [`AuthenticatorChain`](`crate::AuthenticatorChain`) and the axum middleware) and passed
-    /// in so implementations can reuse the already-decoded header and claims instead of
-    /// decoding the token a second time.
+    /// `introspection` must be the result of [`introspect`](`crate::introspect::introspect`)
+    /// for `token`. The caller computes it once and passes it in (the axum middleware does
+    /// this for you). [`AuthenticatorChain`](`crate::AuthenticatorChain`) does not introspect;
+    /// it forwards the value it was given to the selected authenticator. This lets
+    /// implementations reuse the already-decoded header and claims instead of decoding the
+    /// token a second time.
     ///
     /// # Errors
     /// - Token is not valid.

--- a/crates/limes/src/axum.rs
+++ b/crates/limes/src/axum.rs
@@ -27,7 +27,8 @@ pub async fn authentication_middleware<T: Authenticator>(
     };
 
     let token = authorization.token();
-    let auth_result = verifiers.authenticate(token).await;
+    let introspection = crate::introspect::introspect(token);
+    let auth_result = verifiers.authenticate(token, &introspection).await;
 
     match auth_result {
         Ok(auth) => {

--- a/crates/limes/src/chain.rs
+++ b/crates/limes/src/chain.rs
@@ -1,7 +1,7 @@
 use crate::{
     Authentication, Authenticator,
     error::{Error, Result},
-    introspect::{IntrospectionResult, introspect},
+    introspect::IntrospectionResult,
 };
 
 /// Enum to hold the different authenticators.
@@ -50,12 +50,14 @@ where
     /// # Errors
     /// - No authenticator in the chain can handle the token.
     /// - The matching authenticator rejects the token.
-    async fn authenticate(&self, token: &str) -> Result<Authentication> {
-        let introspect_result = introspect(token);
-
+    async fn authenticate(
+        &self,
+        token: &str,
+        introspection: &IntrospectionResult,
+    ) -> Result<Authentication> {
         for authenticator in &self.authenticators {
-            if authenticator.can_handle_token(token, &introspect_result) {
-                return authenticator.authenticate(token).await;
+            if authenticator.can_handle_token(token, introspection) {
+                return authenticator.authenticate(token, introspection).await;
             }
         }
 
@@ -112,12 +114,18 @@ where
 
 #[cfg(any(feature = "kubernetes", feature = "jwks"))]
 impl Authenticator for AuthenticatorEnum {
-    async fn authenticate(&self, token: &str) -> Result<Authentication> {
+    async fn authenticate(
+        &self,
+        token: &str,
+        introspection: &IntrospectionResult,
+    ) -> Result<Authentication> {
         match self {
             #[cfg(feature = "kubernetes")]
-            Self::Kubernetes(authenticator) => authenticator.authenticate(token).await,
+            Self::Kubernetes(authenticator) => {
+                authenticator.authenticate(token, introspection).await
+            }
             #[cfg(feature = "jwks")]
-            Self::Jwt(authenticator) => authenticator.authenticate(token).await,
+            Self::Jwt(authenticator) => authenticator.authenticate(token, introspection).await,
         }
     }
 

--- a/crates/limes/src/introspect.rs
+++ b/crates/limes/src/introspect.rs
@@ -52,8 +52,10 @@ pub fn introspect(token: &str) -> IntrospectionResult {
 
 #[derive(Deserialize)]
 pub(crate) struct JWTBearer {
-    #[allow(unused)]
-    sub: String,
+    // Only `iss` and `aud` are needed to classify and route a token. `sub` is intentionally
+    // not required here so introspection does not reject otherwise-valid tokens (e.g. those
+    // relying on a `subject_claim` override such as `oid`); the subject is resolved later
+    // during full authentication.
     iss: Issuer,
     #[serde(default)]
     aud: Audience,
@@ -164,6 +166,30 @@ mod tests {
             );
         } else {
             panic!("Unexpected result: {introspection_result:?}");
+        }
+    }
+
+    #[test]
+    fn test_introspect_without_sub_claim() {
+        // A token carrying `iss`/`aud` but no `sub` must still classify as a JWT bearer so
+        // that authenticators relying on a `subject_claim` override (e.g. `oid`) keep working.
+        let claims = serde_json::json!({
+            "iss": "https://example.com",
+            "aud": "my-app",
+        });
+        let token = jsonwebtoken::encode(
+            &Header::new(jsonwebtoken::Algorithm::HS256),
+            &claims,
+            &jsonwebtoken::EncodingKey::from_secret(b"secret"),
+        )
+        .unwrap();
+
+        match introspect(&token) {
+            IntrospectionResult::JWTBearer { iss, aud, .. } => {
+                assert!(iss.contains("https://example.com"));
+                assert!(aud.contains("my-app"));
+            }
+            IntrospectionResult::Unknown => panic!("expected JWTBearer for sub-less token"),
         }
     }
 }

--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -246,12 +246,23 @@ impl JWKSWebAuthenticator {
 }
 
 impl Authenticator for JWKSWebAuthenticator {
-    async fn authenticate(&self, token: &str) -> Result<Authentication> {
-        let header = decode_jwt_header(token)?;
-        let key_id = require_jwt_key_id(&header)?;
+    async fn authenticate(
+        &self,
+        token: &str,
+        introspection: &IntrospectionResult,
+    ) -> Result<Authentication> {
+        // Reuse the header decoded during introspection instead of decoding the token again.
+        let IntrospectionResult::JWTBearer { header, .. } = introspection else {
+            return Err(Error::JWTDecodeError {
+                reason: "Token is not a JWT bearer token.".to_string(),
+            });
+        };
+        let key_id = header.kid.as_deref().ok_or_else(|| Error::JWTDecodeError {
+            reason: "Token does not contain a key id".to_string(),
+        })?;
         let key = self
             .client
-            .get_opt(&key_id)
+            .get_opt(key_id)
             .await
             .map_err(|e| Error::RefreshOpenIDWellKnownConfigError {
                 url: self.config_url.to_string(),
@@ -262,7 +273,7 @@ impl Authenticator for JWKSWebAuthenticator {
             })?;
         let token_data = authenticate_jwt(
             token,
-            &header,
+            header,
             &key,
             &self.audiences,
             &self.issuers,
@@ -298,18 +309,6 @@ impl Authenticator for JWKSWebAuthenticator {
             IntrospectionResult::Unknown => false,
         }
     }
-}
-
-fn decode_jwt_header(token: &str) -> Result<Header> {
-    jsonwebtoken::decode_header(token).map_err(|e| Error::JWTDecodeError {
-        reason: format!("Failed to decode JWT header: {e}").to_string(),
-    })
-}
-
-fn require_jwt_key_id(header: &Header) -> Result<String> {
-    header.kid.clone().ok_or_else(|| Error::JWTDecodeError {
-        reason: "Token does not contain a key id".to_string(),
-    })
 }
 
 fn authenticate_jwt(
@@ -381,14 +380,15 @@ fn extract_authentication(
     role_claims: Option<&[String]>,
 ) -> Result<Authentication> {
     let subject_in_idp = get_subject(&token_data, subject_claim)?;
+    let header = token_data.header;
     let claims = token_data.claims;
 
     let subject = Subject::new(idp_id.map(ToString::to_string), subject_in_idp);
 
-    let name = claims.get(NAME_CLAIM).and_then(value_as_string);
+    // `parse_human_name` already returns the `name` claim when present, so a separate
+    // `name` lookup would be redundant.
     let human_name = parse_human_name(&claims);
     let app_name = claims.get(APP_DISPLAYNAME_CLAIM).and_then(value_as_string);
-    let preferred_username = claims.get("preferred_username").and_then(value_as_string);
 
     let principal_type = get_idp_type(&claims)
         // If idp type is not set, try to infer it from the claims
@@ -397,19 +397,25 @@ fn extract_authentication(
         // In Keycloak the client_id is the requesting application
         .or(claims.get("client_id").map(|_t| PrincipalType::Application));
 
-    let roles = get_roles(&claims, role_claims);
+    // Fall back lazily so we only allocate the username string when nothing better matched.
+    let name = human_name
+        .or(app_name)
+        .or_else(|| claims.get("preferred_username").and_then(value_as_string));
 
+    let roles = get_roles(&claims, role_claims);
     let audiences = crate::introspect::parse_aud(claims.get(AUD_CLAIM));
+    let email = get_email(&claims);
 
     Ok(Authentication::builder()
-        .token_header(Some(token_data.header))
-        .claims(claims.clone())
-        .name(name.or(human_name).or(app_name).or(preferred_username))
-        .email(get_email(&claims))
+        .token_header(Some(header))
+        .name(name)
+        .email(email)
         .subject(subject)
         .principal_type(principal_type)
         .roles(roles)
         .audiences(audiences)
+        // Move the claims in last; everything above only borrows them, so no clone is needed.
+        .claims(claims)
         .build())
 }
 
@@ -529,7 +535,7 @@ fn parse_human_name(claims: &serde_json::Value) -> Option<String> {
         .and_then(value_as_string);
 
     claims
-        .get("name")
+        .get(NAME_CLAIM)
         .and_then(value_as_string)
         .or_else(|| match (first_name, last_name) {
             (Some(first), Some(last)) => Some(format!("{first} {last}")),

--- a/crates/limes/src/kubernetes.rs
+++ b/crates/limes/src/kubernetes.rs
@@ -103,25 +103,24 @@ impl KubernetesAuthenticator {
 }
 
 impl Authenticator for KubernetesAuthenticator {
-    async fn authenticate(&self, token: &str) -> Result<Authentication> {
+    async fn authenticate(
+        &self,
+        token: &str,
+        introspection: &IntrospectionResult,
+    ) -> Result<Authentication> {
         // If an issuer is set, the token must be JWT and the issuer must match
         if !self.issuers.is_empty() {
-            let introspection_result = crate::introspect::introspect(token);
-            match introspection_result {
+            match introspection {
                 IntrospectionResult::Unknown => {
                     return Err(Error::unauthenticated(
                         "Expected JWT token for Kubernetes Authenticator as issuer is set",
                     ));
                 }
-                IntrospectionResult::JWTBearer {
-                    iss,
-                    aud: _aud,
-                    header: _,
-                } => {
+                IntrospectionResult::JWTBearer { iss, .. } => {
                     if !self.issuers.iter().any(|i| iss.contains(i)) {
                         return Err(Error::IssuerMismatch {
                             expected: self.issuers.clone(),
-                            actual: iss.into_iter().collect(),
+                            actual: iss.iter().cloned().collect(),
                         });
                     }
                 }

--- a/crates/limes/src/lib.rs
+++ b/crates/limes/src/lib.rs
@@ -138,6 +138,9 @@
 //! * `all`: Activate all features
 //! * `default`: Includes `rustls-tls` and `jwks`.
 //! * `kubernetes`: Provides the `KubernetesAuthenticator` implementation which validates tokens using Kubernetes `TokenReview`.
+//!   When enabling this feature you must also select a Kubernetes API version by adding a direct
+//!   dependency on `k8s-openapi` with a version feature, e.g. `k8s-openapi = { version = "0.28", features = ["v1_32"] }`.
+//!   Limes intentionally does not pin a version so the choice is left to your binary crate.
 //! * `rustls-tls`: Enable `rustls` for all dependant crates.
 //! * `jwks`: Provides the `JWKSWebAuthenticator`
 //! * `axum`: Provides axum middleware that performs the Authentication and provides the tokens Payload as extension.

--- a/examples/multi-tenant/Cargo.toml
+++ b/examples/multi-tenant/Cargo.toml
@@ -10,6 +10,8 @@ license = { workspace = true }
 
 [dependencies]
 axum = { version = "0.8" }
+# limes leaves the Kubernetes version choice to the binary crate, so we select it here.
+k8s-openapi = { version = "0.28", features = ["v1_32"] }
 limes = { path = "../../crates/limes", default-features = false, features = [
     "jwks",
     "rustls-tls",


### PR DESCRIPTION
Authentication no longer decodes a token more than once. Authenticator::authenticate
now receives the IntrospectionResult: AuthenticatorChain and the axum middleware run
introspect() a single time and pass it down, so the JWKS authenticator reuses the
already-decoded header instead of decoding again, the Kubernetes authenticator reuses
it instead of re-introspecting, and the `aud` claim is no longer parsed twice (fixes #58).

Performance:
- Drop the full claims serde_json::Value deep-clone in the JWKS extraction path; the
  claims are moved into the result instead of cloned.
- Remove the redundant `name` lookup (folded into parse_human_name) and make the
  preferred_username fallback lazy so it only allocates when nothing better matched.

Dependencies (latest stable; MSRV unchanged at 1.88):
- kube 2.0 -> 4.0
- k8s-openapi 0.26 -> 0.28
- reqwest 0.12 -> 0.13
- jwks_client_rs 0.5.2 -> 0.6
- jsonwebtoken 10.2 -> 10.4
Adapt to upstream TLS feature renames (rustls-tls -> rustls, rustls-tls-native-roots
-> rustls-native-certs).

k8s-openapi version selection:
- Per k8s-openapi's guidance, the library no longer enables a version feature on its
  direct dependency. The version is selected in dev-dependencies (for our own tests),
  in the multi-tenant example, and by consumers. The docs CI job sets
  K8S_OPENAPI_ENABLED_VERSION so it builds without dev-dependencies.

Docs:
- Correct the authenticate() documentation: AuthenticatorChain forwards the
  introspection it is given; only top-level callers run introspect().

BREAKING CHANGE: Authenticator::authenticate now takes a &IntrospectionResult argument;
custom Authenticator implementations and direct callers must introspect the token and
pass the result. Introspection no longer requires a `sub` claim to classify a token as
a JWT bearer. Enabling the `kubernetes` feature now requires the consuming binary to
select a Kubernetes version via its own k8s-openapi dependency, e.g.
k8s-openapi = { version = "0.28", features = ["v1_32"] }.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * JWT bearer tokens are now recognized even when the `sub` claim is missing.
  * Authentication reuses already-parsed token introspection data across middleware and authenticators to avoid repeated token processing.

* **Chores**
  * Updated TLS/security-related dependencies and bumped core library versions.

* **Documentation**
  * Clarified Kubernetes feature setup, including selecting an appropriate Kubernetes API version for documentation and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->