### PR TITLE
fix: harden Kubernetes token validation and trim hot-path allocations

### DIFF
--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -49,7 +49,8 @@ const AUD_CLAIM: &str = "aud";
 /// - `subject`: `sub` unless `subject_claim` is set, then it will be the value of the claim.
 /// - `claims`: all claims
 /// - `email`: `email` or `upn` if it contains an `@` or `preferred_username` if it contains an `@`
-/// - `principal_type`: Is always `Application` currently.
+/// - `principal_type`: inferred from the claims - `idtyp`, then the presence of a human-name
+///   claim (`Human`), an `app_displayname`/`client_id` claim (`Application`); `None` if undetermined.
 ///
 pub struct JWKSWebAuthenticator {
     idp_id: Option<String>,
@@ -360,12 +361,14 @@ fn authenticate_jwt(
         reason: format!("Failed to decode JWT token. {e}"),
     })?;
 
-    if let Some(scope) = scope {
-        let token_scopes =
-            parse_scope(token_data.claims.get(SCOPE_CLAIM).and_then(value_as_string));
-        if !token_scopes.contains(&scope.to_string()) {
+    if let Some(required_scope) = scope {
+        let scope_claim = token_data
+            .claims
+            .get(SCOPE_CLAIM)
+            .and_then(serde_json::Value::as_str);
+        if !scope_claim_contains(scope_claim, required_scope) {
             return Err(Error::unauthenticated(format!(
-                "Token does not contain required scope `{scope}`."
+                "Token does not contain required scope `{required_scope}`."
             )));
         }
     }
@@ -462,14 +465,12 @@ fn get_roles(claims: &serde_json::Value, role_claims: Option<&[String]>) -> Opti
     }
 
     for claim_path in role_claim_paths {
-        // Split by dots to support nested paths like "resource_access.account.roles"
-        let path_parts: Vec<&str> = claim_path.split('.').collect();
-
-        // Navigate through nested claims
+        // Navigate through nested claims, splitting on '.' to support paths like
+        // "resource_access.account.roles".
         let mut current = claims;
         let mut found = true;
 
-        for part in &path_parts {
+        for part in claim_path.split('.') {
             if let Some(next) = current.get(part) {
                 current = next;
             } else {
@@ -545,17 +546,6 @@ fn parse_human_name(claims: &serde_json::Value) -> Option<String> {
         })
 }
 
-fn parse_scope(scope_in_claims: Option<String>) -> Vec<String> {
-    scope_in_claims
-        .map(|scope| {
-            scope
-                .split(' ')
-                .map(std::string::ToString::to_string)
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
 #[derive(serde::Deserialize, Clone, Debug)]
 struct WellKnownConfig {
     pub jwks_uri: url::Url,
@@ -583,6 +573,12 @@ fn value_as_string(value: &serde_json::Value) -> Option<String> {
     value.as_str().map(std::string::ToString::to_string)
 }
 
+/// Returns `true` if the space-delimited `scope` claim contains `required`.
+/// Matches without allocating an intermediate collection.
+fn scope_claim_contains(scope_claim: Option<&str>, required: &str) -> bool {
+    scope_claim.is_some_and(|scopes| scopes.split_whitespace().any(|s| s == required))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -590,24 +586,25 @@ mod test {
     use std::collections::HashSet;
 
     #[test]
-    fn test_parse_scope_multi() {
-        let scope = Some("openid profile email".to_string());
-        let parsed = parse_scope(scope);
-        assert_eq!(parsed, vec!["openid", "profile", "email"]);
+    fn test_scope_claim_contains_multi() {
+        assert!(scope_claim_contains(
+            Some("openid profile email"),
+            "profile"
+        ));
+        assert!(!scope_claim_contains(Some("openid profile email"), "admin"));
     }
 
     #[test]
-    fn test_parse_scope_empty() {
-        let scope = None;
-        let parsed = parse_scope(scope);
-        assert_eq!(parsed, Vec::<String>::new());
+    fn test_scope_claim_contains_single() {
+        assert!(scope_claim_contains(Some("openid"), "openid"));
+        // Must match a whole scope, not a prefix.
+        assert!(!scope_claim_contains(Some("openid"), "open"));
     }
 
     #[test]
-    fn test_parse_scope_single() {
-        let scope = Some("openid".to_string());
-        let parsed = parse_scope(scope);
-        assert_eq!(parsed, vec!["openid"]);
+    fn test_scope_claim_contains_absent() {
+        assert!(!scope_claim_contains(None, "openid"));
+        assert!(!scope_claim_contains(Some(""), "openid"));
     }
 
     #[test]

--- a/crates/limes/src/kubernetes.rs
+++ b/crates/limes/src/kubernetes.rs
@@ -177,16 +177,24 @@ fn parse_review_status(
     let token_review: TokenReviewStatus = token_review
         .ok_or_else(|| Error::unauthenticated("Kubernetes TokenReview returned no status"))?;
 
-    // Validate Audience
-    let actual_audiences = token_review.audiences.unwrap_or_default();
-    validate_audience(audiences, &actual_audiences)?;
-
     // Raise k8s error
     if let Some(error) = token_review.error {
         return Err(Error::unauthenticated(format!(
             "Kubernetes TokenReview failed: {error}"
         )));
     }
+
+    // The token is only valid if Kubernetes explicitly marked it as authenticated.
+    // Don't rely on the presence of `user` alone to infer this.
+    if token_review.authenticated != Some(true) {
+        return Err(Error::unauthenticated(
+            "Kubernetes TokenReview did not authenticate the token",
+        ));
+    }
+
+    // Validate Audience
+    let actual_audiences = token_review.audiences.unwrap_or_default();
+    validate_audience(audiences, &actual_audiences)?;
 
     // Parse claims
     let user_info: UserInfo = token_review
@@ -312,5 +320,19 @@ mod test {
             payload.audiences(),
             &HashSet::from(["https://kubernetes.default.svc".to_string()])
         );
+    }
+
+    #[test]
+    fn test_parse_review_status_rejects_unauthenticated() {
+        // `authenticated: false` must be rejected even when user info is present.
+        let status = serde_json::json!({
+            "authenticated": false,
+            "user": {
+                "uid": "0e79c2ec-32eb-4a46-ab9b-f075fbbfbd43",
+                "username": "system:serviceaccount:my-namespace:my-serviceaccount"
+            }
+        });
+        let token_review_status: TokenReviewStatus = serde_json::from_value(status).unwrap();
+        parse_review_status(Some(token_review_status), &[], Some("kubernetes")).unwrap_err();
     }
 }


### PR DESCRIPTION
- Kubernetes: require status.authenticated == Some(true) instead of inferring validity from the presence of user info; check the explicit TokenReview error before audience validation.
- JWKS: test the required scope without allocating a Vec + String per call.
- JWKS: drop the per-path Vec allocation in role extraction.
- Fix the JWKSWebAuthenticator doc comment: principal_type is inferred from claims, not always Application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication checks to reject invalid Kubernetes token reviews earlier, including unauthenticated responses even when user details are present.
  * Updated scope validation so required permissions are matched correctly from space-delimited scopes, avoiding partial matches and missing-scope edge cases.
  * Refined role lookup logic for nested claims to preserve existing fallback behavior across multiple claim paths.
* **Documentation**
  * Clarified how principal type is determined in authentication documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->