### PR TITLE
fix(deps): drop removed reqwest `rustls-native-certs` feature

### DIFF
--- a/crates/limes/Cargo.toml
+++ b/crates/limes/Cargo.toml
@@ -24,7 +24,6 @@ rustls-tls = [
     "kube?/rustls-tls",
     "jwks_client_rs?/rustls",
     "reqwest/rustls",
-    "reqwest/rustls-native-certs",
 ]
 aws-lc-rs = ["kube?/aws-lc-rs"]
 ring = ["kube?/ring"]


### PR DESCRIPTION
reqwest deleted the `rustls-native-certs` feature after 0.13.1; native trust-store verification now comes from `rustls-platform-verifier`, which the `rustls` feature already pulls in across the whole 0.13.x range. Referencing the removed feature broke dependency resolution for any consumer resolving reqwest >= 0.13.2, while limes built in isolation only because its own lockfile pins 0.13.1. Keep just `reqwest/rustls`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS configuration by removing an unnecessary certificate dependency, supporting more reliable secure connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->