### PR TITLE
feat(jwks)!: required-claim rules, typed token rejections, stricter validation

### DIFF
--- a/crates/limes/CHANGELOG.md
+++ b/crates/limes/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(claims)* `ClaimRule` — validated rules (`any_of`, `all_of`, `none_of`, `exists`, optional separator) over dotted claim paths, evaluated by `JWKSWebAuthenticator::with_required_claims` after signature, issuer and audience checks. Missing or malformed claims fail closed.
+- *(jwks)* `set_scope` accepts array-shaped `scope` claims and falls back to the `scp` claim; `Authentication::scopes()` does the same.
+- *(error)* `Error::TokenRejected { rejection: RejectionReason }` distinguishes rejected-but-verified tokens (audience, issuer, required claim, missing subject) from unverifiable ones. Carries rule names only, never claim values.
+
+### Changed
+
+- **Breaking:** `Error` is `#[non_exhaustive]`; `Error::AudienceMismatch` and `Error::IssuerMismatch` are replaced by `TokenRejected` (JWKS and Kubernetes authenticators). A missing subject claim, previously `Unauthenticated`, is `TokenRejected`.
+- *(jwks)* A token without an `aud` claim, or with an `aud` that is not a string or array of strings, is rejected when audiences are configured; a token without an `iss` claim is rejected. Previously such tokens passed audience/issuer validation.
+
 ## [0.5.0](https://github.com/vakamo-labs/limes-rs/compare/v0.4.2...v0.5.0) - 2026-08-08
 
 ### Added

--- a/crates/limes/CHANGELOG.md
+++ b/crates/limes/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- *(claims)* `ClaimRule` — validated rules (`any_of`, `all_of`, `none_of`, `exists`, optional separator) over dotted claim paths, evaluated by `JWKSWebAuthenticator::with_required_claims` after signature, issuer and audience checks. Missing or malformed claims fail closed.
-- *(jwks)* `set_scope` accepts array-shaped `scope` claims and falls back to the `scp` claim; `Authentication::scopes()` does the same.
-- *(error)* `Error::TokenRejected { rejection: RejectionReason }` distinguishes rejected-but-verified tokens (audience, issuer, required claim, missing subject) from unverifiable ones. Carries rule names only, never claim values.
-
-### Changed
-
-- **Breaking:** `Error` is `#[non_exhaustive]`; `Error::AudienceMismatch` and `Error::IssuerMismatch` are replaced by `TokenRejected` (JWKS and Kubernetes authenticators). A missing subject claim, previously `Unauthenticated`, is `TokenRejected`.
-- *(jwks)* A token without an `aud` claim, or with an `aud` that is not a string or array of strings, is rejected when audiences are configured; a token without an `iss` claim is rejected. Previously such tokens passed audience/issuer validation.
-
 ## [0.5.0](https://github.com/vakamo-labs/limes-rs/compare/v0.4.2...v0.5.0) - 2026-08-08
 
 ### Added

--- a/crates/limes/Cargo.toml
+++ b/crates/limes/Cargo.toml
@@ -54,7 +54,9 @@ url = { version = "2.5", features = ["serde"] }
 valuable = { version = "0.1.1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
+aws-lc-rs = "1"
 axum = { version = "0.8" }
+base64 = "0.22"
 # Select a Kubernetes version for the crate's own tests only (not forced on consumers).
 k8s-openapi = { version = "0.28", features = ["v1_32"] }
 pretty_assertions = "1.4"

--- a/crates/limes/Cargo.toml
+++ b/crates/limes/Cargo.toml
@@ -60,5 +60,5 @@ base64 = "0.22"
 # Select a Kubernetes version for the crate's own tests only (not forced on consumers).
 k8s-openapi = { version = "0.28", features = ["v1_32"] }
 pretty_assertions = "1.4"
-tokio = { version = "1.43", features = ["rt-multi-thread"] }
+tokio = { version = "1.43", features = ["macros", "net", "rt-multi-thread"] }
 tracing-test = "0.2.5"

--- a/crates/limes/Cargo.toml
+++ b/crates/limes/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "limes"
 resolver = "2"
-version = "0.5.0"
+version = "0.6.0"
 readme = "README.md"
 edition = { workspace = true }
 homepage = { workspace = true }

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -15,6 +15,14 @@ pub(crate) const SCOPE_CLAIM: &str = "scope";
 /// Array-shaped alternative to `scope` emitted by some IdPs; consulted when `scope` is absent.
 pub(crate) const SCP_CLAIM: &str = "scp";
 
+/// The `scope` claim, or `scp` if `scope` is absent or `null`.
+pub(crate) fn scope_claim(claims: &serde_json::Value) -> Option<&serde_json::Value> {
+    [SCOPE_CLAIM, SCP_CLAIM]
+        .into_iter()
+        .filter_map(|c| claims.get(c))
+        .find(|v| !v.is_null())
+}
+
 pub trait Authenticator
 where
     Self: Send + Sync + Clone,
@@ -177,17 +185,14 @@ impl Authentication {
 
     /// Get the scopes of the token from the `scope` claim, or `scp` if `scope` is absent.
     ///
-    /// Values are read as scope enforcement reads them: a whitespace-delimited string or an
-    /// array of strings, each split on whitespace; a malformed claim (an object, or an array
-    /// holding non-scalars) yields nothing. Numbers and booleans, which enforcement compares
-    /// by their string form, are omitted here. Returns an empty iterator if neither claim is
-    /// present.
+    /// Values are read exactly as scope enforcement reads them: a whitespace-delimited string
+    /// or an array of strings, each split on whitespace. Anything else (an object, a number,
+    /// or an array holding non-strings) is malformed and yields nothing. Returns an empty
+    /// iterator if neither claim is present.
     pub fn scopes(&self) -> impl Iterator<Item = &str> {
-        let value = [SCOPE_CLAIM, SCP_CLAIM]
-            .into_iter()
-            .filter_map(|c| self.claims.get(c))
-            .find(|v| !v.is_null());
-        let items = value.and_then(crate::claims::scalars).unwrap_or_default();
+        let items = scope_claim(&self.claims)
+            .and_then(crate::claims::strings)
+            .unwrap_or_default();
         crate::claims::ClaimValues::new(items, Some(&crate::claims::Separator::Whitespace))
             .filter_map(|v| match v {
                 std::borrow::Cow::Borrowed(s) => Some(s),
@@ -284,9 +289,11 @@ mod test {
     }
 
     #[test]
-    fn test_scopes_omits_numbers_and_booleans() {
+    fn test_scopes_of_claim_with_numbers_or_booleans_are_empty_like_enforcement() {
         let auth = auth_with_claims(serde_json::json!({ "scope": ["admin", 42, true] }));
-        assert_eq!(auth.scopes().collect::<Vec<_>>(), ["admin"]);
+        assert_eq!(auth.scopes().count(), 0);
+        let auth = auth_with_claims(serde_json::json!({ "scope": 42 }));
+        assert_eq!(auth.scopes().count(), 0);
     }
 
     #[test]

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -12,6 +12,8 @@ const NOT_BEFORE_CLAIM: &str = "nbf";
 /// The space-delimited OAuth `scope` claim. Shared with the JWKS authenticator so the key
 /// is defined in exactly one place.
 pub(crate) const SCOPE_CLAIM: &str = "scope";
+/// Array-shaped alternative to `scope` emitted by some IdPs; consulted when `scope` is absent.
+pub(crate) const SCP_CLAIM: &str = "scp";
 
 pub trait Authenticator
 where
@@ -173,16 +175,23 @@ impl Authentication {
             .and_then(serde_json::Value::as_str)
     }
 
-    /// Get the scopes of the token, parsed from the space-delimited `scope` claim.
+    /// Get the scopes of the token from the `scope` claim, or `scp` if `scope` is absent.
     ///
-    /// Returns an empty iterator if the `scope` claim is absent. Derived on demand from the
-    /// claims so unused scopes cost nothing on the authentication path.
+    /// Values are read exactly as scope enforcement reads them: a whitespace-delimited string
+    /// or an array of strings, each split on whitespace. A malformed claim (an object, or an
+    /// array holding non-strings) yields nothing. Returns an empty iterator if neither claim
+    /// is present.
     pub fn scopes(&self) -> impl Iterator<Item = &str> {
-        self.claims
-            .get(SCOPE_CLAIM)
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_default()
-            .split_whitespace()
+        let value = [SCOPE_CLAIM, SCP_CLAIM]
+            .into_iter()
+            .filter_map(|c| self.claims.get(c))
+            .find(|v| !v.is_null());
+        let items = value.and_then(crate::claims::scalars).unwrap_or_default();
+        crate::claims::ClaimValues::new(items, Some(&crate::claims::Separator::Whitespace))
+            .filter_map(|v| match v {
+                std::borrow::Cow::Borrowed(s) => Some(s),
+                std::borrow::Cow::Owned(_) => None,
+            })
     }
 
     #[must_use]
@@ -245,6 +254,40 @@ mod test {
             ["openid", "profile", "email"]
         );
         assert!(auth.all_claims().get("iss").is_some());
+    }
+
+    #[test]
+    fn test_scopes_accepts_array_claim() {
+        let auth = auth_with_claims(serde_json::json!({ "scope": ["openid", "email"] }));
+        assert_eq!(auth.scopes().collect::<Vec<_>>(), ["openid", "email"]);
+    }
+
+    #[test]
+    fn test_scopes_falls_back_to_scp() {
+        let auth = auth_with_claims(serde_json::json!({ "scp": ["openid", "email"] }));
+        assert_eq!(auth.scopes().collect::<Vec<_>>(), ["openid", "email"]);
+        let auth = auth_with_claims(serde_json::json!({ "scp": "openid email" }));
+        assert_eq!(auth.scopes().collect::<Vec<_>>(), ["openid", "email"]);
+        // `scope` present wins, even when `scp` is also present.
+        let auth = auth_with_claims(serde_json::json!({ "scope": "a", "scp": "b" }));
+        assert_eq!(auth.scopes().collect::<Vec<_>>(), ["a"]);
+    }
+
+    #[test]
+    fn test_scopes_splits_array_elements_like_enforcement() {
+        let auth = auth_with_claims(serde_json::json!({ "scope": ["openid profile", "email"] }));
+        assert_eq!(
+            auth.scopes().collect::<Vec<_>>(),
+            ["openid", "profile", "email"]
+        );
+    }
+
+    #[test]
+    fn test_scopes_of_malformed_claim_are_empty_like_enforcement() {
+        let auth = auth_with_claims(serde_json::json!({ "scope": ["admin", {"k": "v"}] }));
+        assert_eq!(auth.scopes().count(), 0);
+        let auth = auth_with_claims(serde_json::json!({ "scope": ["admin", null] }));
+        assert_eq!(auth.scopes().count(), 0);
     }
 
     #[test]

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -177,10 +177,11 @@ impl Authentication {
 
     /// Get the scopes of the token from the `scope` claim, or `scp` if `scope` is absent.
     ///
-    /// Values are read exactly as scope enforcement reads them: a whitespace-delimited string
-    /// or an array of strings, each split on whitespace. A malformed claim (an object, or an
-    /// array holding non-strings) yields nothing. Returns an empty iterator if neither claim
-    /// is present.
+    /// Values are read as scope enforcement reads them: a whitespace-delimited string or an
+    /// array of strings, each split on whitespace; a malformed claim (an object, or an array
+    /// holding non-scalars) yields nothing. Numbers and booleans, which enforcement compares
+    /// by their string form, are omitted here. Returns an empty iterator if neither claim is
+    /// present.
     pub fn scopes(&self) -> impl Iterator<Item = &str> {
         let value = [SCOPE_CLAIM, SCP_CLAIM]
             .into_iter()
@@ -280,6 +281,12 @@ mod test {
             auth.scopes().collect::<Vec<_>>(),
             ["openid", "profile", "email"]
         );
+    }
+
+    #[test]
+    fn test_scopes_omits_numbers_and_booleans() {
+        let auth = auth_with_claims(serde_json::json!({ "scope": ["admin", 42, true] }));
+        assert_eq!(auth.scopes().collect::<Vec<_>>(), ["admin"]);
     }
 
     #[test]

--- a/crates/limes/src/claims.rs
+++ b/crates/limes/src/claims.rs
@@ -25,6 +25,11 @@ pub enum ClaimOperator {
     /// Every value of the set is a claim value.
     AllOf(HashSet<String>),
     /// No claim value is in the set. A missing claim fails.
+    ///
+    /// A value is the *whole* string unless a separator is configured: without one,
+    /// `none_of ["admin"]` does NOT fire on `"scope": "openid admin"` — that claim's single
+    /// value is `"openid admin"`. Configure the separator that matches the claim's format
+    /// when denying values inside delimited strings.
     NoneOf(HashSet<String>),
     /// `true`: the claim is present and not `null`; `false`: absent or `null`.
     Exists(bool),
@@ -60,18 +65,73 @@ pub struct ClaimRule {
 }
 
 impl ClaimRule {
-    /// Build a rule for `claim`, a claim name or a dotted path such as `realm_access.roles`.
-    /// A name containing dots (e.g. `https://example.com/roles`) is looked up as a whole key
-    /// first; only if no such key exists is it walked as a path.
+    /// At least one of `values` must be a value of `claim`.
+    ///
+    /// `claim` is a claim name or a dotted path such as `realm_access.roles`. Every dot
+    /// nests: a claim whose name itself contains a dot (e.g. the URI-shaped
+    /// `https://example.com/roles`) is not addressable. The same applies to all constructors.
     ///
     /// # Errors
     /// See [`ClaimRuleError`].
-    pub fn new(
+    pub fn any_of<I: IntoIterator<Item = S>, S: Into<String>>(
+        claim: impl Into<String>,
+        values: I,
+    ) -> Result<Self, ClaimRuleError> {
+        Self::new(claim, None, ClaimOperator::AnyOf(collect(values)))
+    }
+
+    /// Every one of `values` must be a value of `claim`.
+    ///
+    /// # Errors
+    /// See [`ClaimRuleError`].
+    pub fn all_of<I: IntoIterator<Item = S>, S: Into<String>>(
+        claim: impl Into<String>,
+        values: I,
+    ) -> Result<Self, ClaimRuleError> {
+        Self::new(claim, None, ClaimOperator::AllOf(collect(values)))
+    }
+
+    /// None of `values` may be a value of `claim`; a missing claim fails.
+    ///
+    /// # Errors
+    /// See [`ClaimRuleError`].
+    pub fn none_of<I: IntoIterator<Item = S>, S: Into<String>>(
+        claim: impl Into<String>,
+        values: I,
+    ) -> Result<Self, ClaimRuleError> {
+        Self::new(claim, None, ClaimOperator::NoneOf(collect(values)))
+    }
+
+    /// `claim` must be present and not `null` (`true`), or absent or `null` (`false`).
+    ///
+    /// # Errors
+    /// See [`ClaimRuleError`].
+    pub fn exists(claim: impl Into<String>, expected: bool) -> Result<Self, ClaimRuleError> {
+        Self::new(claim, None, ClaimOperator::Exists(expected))
+    }
+
+    /// Split string claim values on `separator` before matching.
+    ///
+    /// # Errors
+    /// [`ClaimRuleError::EmptySeparator`], or [`ClaimRuleError::ValueContainsSeparator`] if a
+    /// listed value contains the separator (it could never match a split piece).
+    pub fn with_separator(self, separator: Separator) -> Result<Self, ClaimRuleError> {
+        Self::new_with_claims(self.claims, Some(separator), self.operator)
+    }
+
+    pub(crate) fn new(
         claim: impl Into<String>,
         separator: Option<Separator>,
         operator: ClaimOperator,
     ) -> Result<Self, ClaimRuleError> {
-        let claim = validate_path(claim.into())?;
+        Self::new_with_claims(vec![validate_path(claim.into())?], separator, operator)
+    }
+
+    fn new_with_claims(
+        claims: Vec<String>,
+        separator: Option<Separator>,
+        operator: ClaimOperator,
+    ) -> Result<Self, ClaimRuleError> {
         if matches!(&separator, Some(Separator::Literal(literal)) if literal.is_empty()) {
             return Err(ClaimRuleError::EmptySeparator);
         }
@@ -101,7 +161,7 @@ impl ClaimRule {
             }
         }
         Ok(Self {
-            claims: vec![claim],
+            claims,
             separator,
             operator,
         })
@@ -121,13 +181,13 @@ impl ClaimRule {
 
     /// The claim paths in lookup order.
     #[must_use]
-    pub fn claims(&self) -> &[String] {
+    pub(crate) fn claims(&self) -> &[String] {
         &self.claims
     }
 
     /// The operator.
-    #[must_use]
-    pub fn operator(&self) -> &ClaimOperator {
+    #[cfg(test)]
+    pub(crate) fn operator(&self) -> &ClaimOperator {
         &self.operator
     }
 
@@ -171,8 +231,24 @@ pub(crate) fn scalars(value: &serde_json::Value) -> Option<&[serde_json::Value]>
     }
 }
 
+/// Like [`scalars`], but only a string or an array of strings qualifies; numbers and booleans
+/// make the claim malformed. Used for scopes, which are strings by definition.
+pub(crate) fn strings(value: &serde_json::Value) -> Option<&[serde_json::Value]> {
+    match value {
+        serde_json::Value::Array(items) if items.iter().all(serde_json::Value::is_string) => {
+            Some(items)
+        }
+        serde_json::Value::String(_) => Some(std::slice::from_ref(value)),
+        _ => None,
+    }
+}
+
 fn is_scalar(value: &serde_json::Value) -> bool {
     value.is_string() || value.is_number() || value.is_boolean()
+}
+
+fn collect<I: IntoIterator<Item = S>, S: Into<String>>(values: I) -> HashSet<String> {
+    values.into_iter().map(Into::into).collect()
 }
 
 fn validate_path(path: String) -> Result<String, ClaimRuleError> {
@@ -235,16 +311,14 @@ impl<'a> Iterator for ClaimValues<'a> {
     }
 }
 
-/// Look up a claim by its whole name, or navigate nested claims using dot-notation
-/// (e.g. `resource_access.account.roles`) if no key of that name exists. Returns `None` if
-/// the path is absent.
+/// Navigate nested claims using dot-notation (e.g. `resource_access.account.roles`).
+/// Every dot nests — a claim whose *name* contains a dot (e.g. the URI-shaped
+/// `https://example.com/roles`) is not addressable, so a flat key can never shadow the
+/// nested claim a rule targets. Returns `None` if the path is absent.
 pub(crate) fn navigate<'a>(
     claims: &'a serde_json::Value,
     dot_path: &str,
 ) -> Option<&'a serde_json::Value> {
-    if let Some(whole) = claims.get(dot_path) {
-        return Some(whole);
-    }
     let mut current = claims;
     for part in dot_path.split('.') {
         current = current.get(part)?;
@@ -281,6 +355,57 @@ mod tests {
     }
 
     // ---- construction ----
+
+    #[test]
+    fn named_constructors_build_the_same_rules_as_new() {
+        assert_eq!(
+            ClaimRule::any_of("c", ["a", "b"]).unwrap(),
+            rule("c", any_of(&["a", "b"]))
+        );
+        assert_eq!(
+            ClaimRule::all_of("c", ["a"]).unwrap(),
+            rule("c", all_of(&["a"]))
+        );
+        assert_eq!(
+            ClaimRule::none_of("c", ["a"]).unwrap(),
+            rule("c", none_of(&["a"]))
+        );
+        assert_eq!(
+            ClaimRule::exists("c", true).unwrap(),
+            rule("c", ClaimOperator::Exists(true))
+        );
+        assert_eq!(
+            ClaimRule::any_of("c", ["a"])
+                .unwrap()
+                .with_separator(Separator::Whitespace)
+                .unwrap(),
+            rule_sep("c", Separator::Whitespace, any_of(&["a"]))
+        );
+        // `with_separator` revalidates values against the separator.
+        assert_eq!(
+            ClaimRule::none_of("groups", ["Domain Admins"])
+                .unwrap()
+                .with_separator(Separator::Whitespace)
+                .unwrap_err(),
+            ClaimRuleError::ValueContainsSeparator {
+                operator: "none_of",
+                value: "Domain Admins".to_string(),
+            }
+        );
+        // The separator survives `or_claim`.
+        assert_eq!(
+            ClaimRule::all_of("scope", ["x"])
+                .unwrap()
+                .with_separator(Separator::Whitespace)
+                .unwrap()
+                .or_claim("scp")
+                .unwrap(),
+            ClaimRule::new("scope", Some(Separator::Whitespace), all_of(&["x"]))
+                .unwrap()
+                .or_claim("scp")
+                .unwrap()
+        );
+    }
 
     #[test]
     fn new_rejects_empty_claim_path() {
@@ -561,15 +686,39 @@ mod tests {
         assert!(!rule("realm_access.missing", ClaimOperator::Exists(true)).matches(&claims));
     }
 
+    /// Every dot nests. A flat key spelled like the path is a *different*, unaddressable
+    /// claim — it can never shadow the nested claim a rule targets, so a token cannot
+    /// smuggle a flat `realm_access.roles` key past a deny rule.
     #[test]
-    fn claim_name_containing_dots_is_matched_as_a_whole_key_first() {
-        let claims = json!({ "https://example.com/roles": ["admin"], "a": { "b": "nested" } });
-        assert!(rule("https://example.com/roles", any_of(&["admin"])).matches(&claims));
-        assert!(rule("a.b", any_of(&["nested"])).matches(&claims));
-        // A whole key wins over a path of the same spelling.
-        let both = json!({ "a.b": "whole", "a": { "b": "nested" } });
-        assert!(rule("a.b", any_of(&["whole"])).matches(&both));
-        assert!(!rule("a.b", any_of(&["nested"])).matches(&both));
+    fn dots_always_nest_and_flat_keys_never_shadow() {
+        let both = json!({ "a.b": "flat", "a": { "b": "nested" } });
+        assert!(rule("a.b", any_of(&["nested"])).matches(&both));
+        assert!(!rule("a.b", any_of(&["flat"])).matches(&both));
+
+        let attack = json!({
+            "realm_access.roles": ["ok"],
+            "realm_access": { "roles": ["banned"] },
+        });
+        assert!(!rule("realm_access.roles", none_of(&["banned"])).matches(&attack));
+
+        // A `null` flat key cannot hide the nested claim from `exists`.
+        let null_flat = json!({ "a.b": null, "a": { "b": "real" } });
+        assert!(rule("a.b", ClaimOperator::Exists(true)).matches(&null_flat));
+        assert!(!rule("a.b", ClaimOperator::Exists(false)).matches(&null_flat));
+
+        // Consequence: a URI-shaped claim name is not addressable.
+        let uri = json!({ "https://example.com/roles": ["admin"] });
+        assert!(!rule("https://example.com/roles", any_of(&["admin"])).matches(&uri));
+        assert!(!rule("https://example.com/roles", ClaimOperator::Exists(true)).matches(&uri));
+    }
+
+    /// Pins the documented `none_of` semantics: without a separator the whole string is one
+    /// value, so denies inside delimited strings need the matching separator.
+    #[test]
+    fn none_of_without_separator_treats_the_whole_string_as_one_value() {
+        let claims = claims_with(&json!("openid admin"));
+        assert!(rule("c", none_of(&["admin"])).matches(&claims));
+        assert!(!rule_sep("c", Separator::Whitespace, none_of(&["admin"])).matches(&claims));
     }
 
     #[test]

--- a/crates/limes/src/claims.rs
+++ b/crates/limes/src/claims.rs
@@ -8,6 +8,7 @@ use std::{borrow::Cow, collections::HashSet};
 
 /// How a string claim is split into values before set operators are applied.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Separator {
     /// Split on any Unicode whitespace (the OAuth `scope` convention).
     Whitespace,
@@ -17,6 +18,7 @@ pub enum Separator {
 
 /// The single operator of a [`ClaimRule`].
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ClaimOperator {
     /// At least one claim value is in the set.
     AnyOf(HashSet<String>),
@@ -40,6 +42,13 @@ pub enum ClaimRuleError {
     EmptyValue { operator: &'static str },
     #[error("separator must not be empty")]
     EmptySeparator,
+    /// A value the separator would split can never equal a split piece, so the rule could
+    /// never match it — and a `none_of` rule would never deny it.
+    #[error("{operator} value `{value}` contains the separator")]
+    ValueContainsSeparator {
+        operator: &'static str,
+        value: String,
+    },
 }
 
 /// A validated rule over one claim.
@@ -51,7 +60,9 @@ pub struct ClaimRule {
 }
 
 impl ClaimRule {
-    /// Build a rule for `claim` (a dotted path such as `realm_access.roles`).
+    /// Build a rule for `claim`, a claim name or a dotted path such as `realm_access.roles`.
+    /// A name containing dots (e.g. `https://example.com/roles`) is looked up as a whole key
+    /// first; only if no such key exists is it walked as a path.
     ///
     /// # Errors
     /// See [`ClaimRuleError`].
@@ -76,6 +87,17 @@ impl ClaimRule {
             }
             if values.iter().any(String::is_empty) {
                 return Err(ClaimRuleError::EmptyValue { operator: name });
+            }
+            let split_by_separator = |v: &str| match &separator {
+                Some(Separator::Whitespace) => v.contains(char::is_whitespace),
+                Some(Separator::Literal(sep)) => v.contains(sep.as_str()),
+                None => false,
+            };
+            if let Some(value) = values.iter().find(|v| split_by_separator(v)) {
+                return Err(ClaimRuleError::ValueContainsSeparator {
+                    operator: name,
+                    value: value.clone(),
+                });
             }
         }
         Ok(Self {
@@ -213,13 +235,16 @@ impl<'a> Iterator for ClaimValues<'a> {
     }
 }
 
-/// Navigate nested JSON claims using dot-notation (e.g. `resource_access.account.roles`).
-/// Returns the value at the path, or `None` if any segment is absent.
-#[must_use]
-pub fn navigate<'a>(
+/// Look up a claim by its whole name, or navigate nested claims using dot-notation
+/// (e.g. `resource_access.account.roles`) if no key of that name exists. Returns `None` if
+/// the path is absent.
+pub(crate) fn navigate<'a>(
     claims: &'a serde_json::Value,
     dot_path: &str,
 ) -> Option<&'a serde_json::Value> {
+    if let Some(whole) = claims.get(dot_path) {
+        return Some(whole);
+    }
     let mut current = claims;
     for part in dot_path.split('.') {
         current = current.get(part)?;
@@ -299,6 +324,32 @@ mod tests {
     }
 
     #[test]
+    fn new_rejects_values_the_separator_would_split() {
+        assert_eq!(
+            ClaimRule::new(
+                "groups",
+                Some(Separator::Whitespace),
+                none_of(&["Domain Admins"])
+            )
+            .unwrap_err(),
+            ClaimRuleError::ValueContainsSeparator {
+                operator: "none_of",
+                value: "Domain Admins".to_string(),
+            }
+        );
+        assert_eq!(
+            ClaimRule::new("c", Some(Separator::Literal(",".into())), any_of(&["a,b"]))
+                .unwrap_err(),
+            ClaimRuleError::ValueContainsSeparator {
+                operator: "any_of",
+                value: "a,b".to_string(),
+            }
+        );
+        // Without a separator a value may contain anything.
+        assert!(ClaimRule::new("c", None, none_of(&["Domain Admins"])).is_ok());
+    }
+
+    #[test]
     fn new_rejects_empty_literal_separator() {
         assert_eq!(
             ClaimRule::new("c", Some(Separator::Literal(String::new())), any_of(&["a"]))
@@ -354,6 +405,17 @@ mod tests {
         assert!(rule("c", any_of(&["1.5"])).matches(&claims_with(&json!(1.5))));
         assert!(rule("c", any_of(&["true"])).matches(&claims_with(&json!(true))));
         assert!(!rule("c", any_of(&["True"])).matches(&claims_with(&json!(true))));
+    }
+
+    #[test]
+    fn whitespace_only_string_with_separator_has_no_values() {
+        let claims = claims_with(&json!("   "));
+        let r = |op| rule_sep("c", Separator::Whitespace, op);
+        assert!(!r(any_of(&["a"])).matches(&claims));
+        assert!(!r(all_of(&["a"])).matches(&claims));
+        // Like an empty array: present, nothing to deny.
+        assert!(r(none_of(&["a"])).matches(&claims));
+        assert!(r(ClaimOperator::Exists(true)).matches(&claims));
     }
 
     #[test]
@@ -448,8 +510,9 @@ mod tests {
         let r = |op| rule_sep("c", Separator::Whitespace, op);
         assert!(r(all_of(&["openid", "email", "profile"])).matches(&claims));
         assert!(!r(any_of(&["open"])).matches(&claims));
-        // No empty values from the double space.
-        assert!(!r(any_of(&[" "])).matches(&claims));
+        // The double space yields no empty value.
+        assert!(!r(ClaimOperator::Exists(false)).matches(&claims));
+        assert!(r(none_of(&["x"])).matches(&claims));
     }
 
     #[test]
@@ -457,8 +520,11 @@ mod tests {
         let claims = claims_with(&json!("a,,b,"));
         let r = rule_sep("c", Separator::Literal(",".into()), all_of(&["a", "b"]));
         assert!(r.matches(&claims));
-        let r = rule_sep("c", Separator::Literal(",".into()), none_of(&["a,,b,"]));
+        // Exactly the two pieces: nothing else to deny.
+        let r = rule_sep("c", Separator::Literal(",".into()), none_of(&["c"]));
         assert!(r.matches(&claims));
+        let r = rule_sep("c", Separator::Literal(",".into()), none_of(&["b"]));
+        assert!(!r.matches(&claims));
     }
 
     #[test]
@@ -482,7 +548,7 @@ mod tests {
     #[test]
     fn separator_does_not_apply_to_numbers() {
         let claims = claims_with(&json!(1.5));
-        let r = rule_sep("c", Separator::Literal(".".into()), any_of(&["1.5"]));
+        let r = rule_sep("c", Separator::Literal(",".into()), any_of(&["1.5"]));
         assert!(r.matches(&claims));
     }
 
@@ -493,6 +559,23 @@ mod tests {
         let claims = json!({ "realm_access": { "roles": ["admin"] } });
         assert!(rule("realm_access.roles", any_of(&["admin"])).matches(&claims));
         assert!(!rule("realm_access.missing", ClaimOperator::Exists(true)).matches(&claims));
+    }
+
+    #[test]
+    fn claim_name_containing_dots_is_matched_as_a_whole_key_first() {
+        let claims = json!({ "https://example.com/roles": ["admin"], "a": { "b": "nested" } });
+        assert!(rule("https://example.com/roles", any_of(&["admin"])).matches(&claims));
+        assert!(rule("a.b", any_of(&["nested"])).matches(&claims));
+        // A whole key wins over a path of the same spelling.
+        let both = json!({ "a.b": "whole", "a": { "b": "nested" } });
+        assert!(rule("a.b", any_of(&["whole"])).matches(&both));
+        assert!(!rule("a.b", any_of(&["nested"])).matches(&both));
+    }
+
+    #[test]
+    fn fallback_is_not_consulted_when_primary_is_present_but_malformed() {
+        let r = rule("scope", any_of(&["x"])).or_claim("scp").unwrap();
+        assert!(!r.matches(&json!({ "scope": {"k": "v"}, "scp": ["x"] })));
     }
 
     #[test]

--- a/crates/limes/src/claims.rs
+++ b/crates/limes/src/claims.rs
@@ -1,0 +1,538 @@
+//! Rules over verified token claims.
+//!
+//! A [`ClaimRule`] is evaluated against the decoded claims of a token whose signature,
+//! issuer and audience have already been verified. Rules are validated at construction
+//! and matched with [`ClaimRule::matches`].
+
+use std::{borrow::Cow, collections::HashSet};
+
+/// How a string claim is split into values before set operators are applied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Separator {
+    /// Split on any Unicode whitespace (the OAuth `scope` convention).
+    Whitespace,
+    /// Split on an exact, non-empty literal.
+    Literal(String),
+}
+
+/// The single operator of a [`ClaimRule`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimOperator {
+    /// At least one claim value is in the set.
+    AnyOf(HashSet<String>),
+    /// Every value of the set is a claim value.
+    AllOf(HashSet<String>),
+    /// No claim value is in the set. A missing claim fails.
+    NoneOf(HashSet<String>),
+    /// `true`: the claim is present and not `null`; `false`: absent or `null`.
+    Exists(bool),
+}
+
+/// A structurally invalid rule, rejected at construction.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ClaimRuleError {
+    #[error("claim path must not be empty or contain empty segments")]
+    InvalidClaimPath,
+    #[error("{operator} must not be empty")]
+    EmptyValueList { operator: &'static str },
+    #[error("{operator} must not contain empty strings")]
+    EmptyValue { operator: &'static str },
+    #[error("separator must not be empty")]
+    EmptySeparator,
+}
+
+/// A validated rule over one claim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimRule {
+    claims: Vec<String>,
+    separator: Option<Separator>,
+    operator: ClaimOperator,
+}
+
+impl ClaimRule {
+    /// Build a rule for `claim` (a dotted path such as `realm_access.roles`).
+    ///
+    /// # Errors
+    /// See [`ClaimRuleError`].
+    pub fn new(
+        claim: impl Into<String>,
+        separator: Option<Separator>,
+        operator: ClaimOperator,
+    ) -> Result<Self, ClaimRuleError> {
+        let claim = validate_path(claim.into())?;
+        if matches!(&separator, Some(Separator::Literal(literal)) if literal.is_empty()) {
+            return Err(ClaimRuleError::EmptySeparator);
+        }
+        let (name, values) = match &operator {
+            ClaimOperator::AnyOf(v) => ("any_of", Some(v)),
+            ClaimOperator::AllOf(v) => ("all_of", Some(v)),
+            ClaimOperator::NoneOf(v) => ("none_of", Some(v)),
+            ClaimOperator::Exists(_) => ("exists", None),
+        };
+        if let Some(values) = values {
+            if values.is_empty() {
+                return Err(ClaimRuleError::EmptyValueList { operator: name });
+            }
+            if values.iter().any(String::is_empty) {
+                return Err(ClaimRuleError::EmptyValue { operator: name });
+            }
+        }
+        Ok(Self {
+            claims: vec![claim],
+            separator,
+            operator,
+        })
+    }
+
+    /// Add a fallback claim path, consulted only when every earlier path is absent or `null`.
+    ///
+    /// The first present path decides the rule alone: with `none_of`, a banned value that
+    /// appears only in a fallback path is not seen when the primary path is present.
+    ///
+    /// # Errors
+    /// [`ClaimRuleError::InvalidClaimPath`] if the path is empty or has empty segments.
+    pub fn or_claim(mut self, claim: impl Into<String>) -> Result<Self, ClaimRuleError> {
+        self.claims.push(validate_path(claim.into())?);
+        Ok(self)
+    }
+
+    /// The claim paths in lookup order.
+    #[must_use]
+    pub fn claims(&self) -> &[String] {
+        &self.claims
+    }
+
+    /// The operator.
+    #[must_use]
+    pub fn operator(&self) -> &ClaimOperator {
+        &self.operator
+    }
+
+    /// Evaluate the rule against decoded claims.
+    ///
+    /// The claim is the first path that is present and not `null`; if there is none it is
+    /// *missing*. A present claim is a set of values: a scalar is its canonical string, an
+    /// array of scalars is its elements, and strings are split by the separator. Objects and
+    /// arrays holding non-scalars are *malformed*: they exist but match no value.
+    #[must_use]
+    pub fn matches(&self, claims: &serde_json::Value) -> bool {
+        let value = self
+            .claims
+            .iter()
+            .filter_map(|path| navigate(claims, path))
+            .find(|v| !v.is_null());
+        let items = value.and_then(scalars);
+        let separator = self.separator.as_ref();
+        let values = || items.map(|items| ClaimValues::new(items, separator));
+        match &self.operator {
+            ClaimOperator::Exists(expected) => value.is_some() == *expected,
+            ClaimOperator::AnyOf(set) => values().is_some_and(|mut v| v.any(|x| set.contains(&*x))),
+            ClaimOperator::NoneOf(set) => {
+                values().is_some_and(|mut v| !v.any(|x| set.contains(&*x)))
+            }
+            ClaimOperator::AllOf(set) => items.is_some_and(|items| {
+                set.iter()
+                    .all(|needle| ClaimValues::new(items, separator).any(|x| *x == **needle))
+            }),
+        }
+    }
+}
+
+/// The scalar items of a claim value: the value itself, or the elements of an array of
+/// scalars. `None` for objects and arrays holding non-scalars.
+pub(crate) fn scalars(value: &serde_json::Value) -> Option<&[serde_json::Value]> {
+    match value {
+        serde_json::Value::Array(items) if items.iter().all(is_scalar) => Some(items),
+        v if is_scalar(v) => Some(std::slice::from_ref(v)),
+        _ => None,
+    }
+}
+
+fn is_scalar(value: &serde_json::Value) -> bool {
+    value.is_string() || value.is_number() || value.is_boolean()
+}
+
+fn validate_path(path: String) -> Result<String, ClaimRuleError> {
+    if path.is_empty() || path.split('.').any(str::is_empty) {
+        return Err(ClaimRuleError::InvalidClaimPath);
+    }
+    Ok(path)
+}
+
+/// Streams the comparable values of scalar items without collecting: strings are borrowed
+/// (and split by the separator, empty pieces dropped), numbers and booleans are formatted.
+pub(crate) struct ClaimValues<'a> {
+    items: std::slice::Iter<'a, serde_json::Value>,
+    separator: Option<&'a Separator>,
+    pending: Option<Pieces<'a>>,
+}
+
+enum Pieces<'a> {
+    Whitespace(std::str::SplitWhitespace<'a>),
+    Literal(std::str::Split<'a, &'a str>),
+}
+
+impl<'a> ClaimValues<'a> {
+    pub(crate) fn new(items: &'a [serde_json::Value], separator: Option<&'a Separator>) -> Self {
+        Self {
+            items: items.iter(),
+            separator,
+            pending: None,
+        }
+    }
+}
+
+impl<'a> Iterator for ClaimValues<'a> {
+    type Item = Cow<'a, str>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(pieces) = &mut self.pending {
+                let piece = match pieces {
+                    Pieces::Whitespace(it) => it.next(),
+                    Pieces::Literal(it) => it.find(|p| !p.is_empty()),
+                };
+                match piece {
+                    Some(p) => return Some(Cow::Borrowed(p)),
+                    None => self.pending = None,
+                }
+            }
+            let item = self.items.next()?;
+            match (item, self.separator) {
+                (serde_json::Value::String(s), None) => return Some(Cow::Borrowed(s)),
+                (serde_json::Value::String(s), Some(Separator::Whitespace)) => {
+                    self.pending = Some(Pieces::Whitespace(s.split_whitespace()));
+                }
+                (serde_json::Value::String(s), Some(Separator::Literal(sep))) => {
+                    self.pending = Some(Pieces::Literal(s.split(sep.as_str())));
+                }
+                (other, _) => return Some(Cow::Owned(other.to_string())),
+            }
+        }
+    }
+}
+
+/// Navigate nested JSON claims using dot-notation (e.g. `resource_access.account.roles`).
+/// Returns the value at the path, or `None` if any segment is absent.
+#[must_use]
+pub fn navigate<'a>(
+    claims: &'a serde_json::Value,
+    dot_path: &str,
+) -> Option<&'a serde_json::Value> {
+    let mut current = claims;
+    for part in dot_path.split('.') {
+        current = current.get(part)?;
+    }
+    Some(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use serde_json::{Value, json};
+
+    fn set(values: &[&str]) -> HashSet<String> {
+        values.iter().map(ToString::to_string).collect()
+    }
+
+    fn rule(claim: &str, operator: ClaimOperator) -> ClaimRule {
+        ClaimRule::new(claim, None, operator).unwrap()
+    }
+
+    fn rule_sep(claim: &str, separator: Separator, operator: ClaimOperator) -> ClaimRule {
+        ClaimRule::new(claim, Some(separator), operator).unwrap()
+    }
+
+    fn any_of(values: &[&str]) -> ClaimOperator {
+        ClaimOperator::AnyOf(set(values))
+    }
+    fn all_of(values: &[&str]) -> ClaimOperator {
+        ClaimOperator::AllOf(set(values))
+    }
+    fn none_of(values: &[&str]) -> ClaimOperator {
+        ClaimOperator::NoneOf(set(values))
+    }
+
+    // ---- construction ----
+
+    #[test]
+    fn new_rejects_empty_claim_path() {
+        assert_eq!(
+            ClaimRule::new("", None, any_of(&["a"])).unwrap_err(),
+            ClaimRuleError::InvalidClaimPath
+        );
+    }
+
+    #[test]
+    fn new_rejects_empty_path_segments() {
+        for path in ["a..b", ".a", "a.", "."] {
+            assert_eq!(
+                ClaimRule::new(path, None, any_of(&["a"])).unwrap_err(),
+                ClaimRuleError::InvalidClaimPath,
+                "path {path:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn new_rejects_empty_value_lists() {
+        for (operator, name) in [
+            (ClaimOperator::AnyOf(HashSet::new()), "any_of"),
+            (ClaimOperator::AllOf(HashSet::new()), "all_of"),
+            (ClaimOperator::NoneOf(HashSet::new()), "none_of"),
+        ] {
+            assert_eq!(
+                ClaimRule::new("c", None, operator).unwrap_err(),
+                ClaimRuleError::EmptyValueList { operator: name }
+            );
+        }
+    }
+
+    #[test]
+    fn new_rejects_empty_string_values() {
+        assert_eq!(
+            ClaimRule::new("c", None, any_of(&["a", ""])).unwrap_err(),
+            ClaimRuleError::EmptyValue { operator: "any_of" }
+        );
+    }
+
+    #[test]
+    fn new_rejects_empty_literal_separator() {
+        assert_eq!(
+            ClaimRule::new("c", Some(Separator::Literal(String::new())), any_of(&["a"]))
+                .unwrap_err(),
+            ClaimRuleError::EmptySeparator
+        );
+    }
+
+    #[test]
+    fn new_accepts_exists_without_values() {
+        let r = rule("c", ClaimOperator::Exists(true));
+        assert_eq!(r.claims(), &["c".to_string()]);
+        assert_eq!(r.operator(), &ClaimOperator::Exists(true));
+    }
+
+    #[test]
+    fn or_claim_appends_fallback_and_validates() {
+        let r = rule("scope", all_of(&["x"])).or_claim("scp").unwrap();
+        assert_eq!(r.claims(), &["scope".to_string(), "scp".to_string()]);
+        assert_eq!(
+            rule("scope", all_of(&["x"])).or_claim("a..b").unwrap_err(),
+            ClaimRuleError::InvalidClaimPath
+        );
+    }
+
+    // ---- value shapes ----
+
+    fn claims_with(value: &Value) -> Value {
+        json!({ "sub": "u", "c": value })
+    }
+
+    #[test]
+    fn string_claim_is_a_single_value() {
+        let claims = claims_with(&json!("admin"));
+        assert!(rule("c", any_of(&["admin", "x"])).matches(&claims));
+        assert!(rule("c", all_of(&["admin"])).matches(&claims));
+        assert!(!rule("c", all_of(&["admin", "x"])).matches(&claims));
+        assert!(rule("c", none_of(&["x"])).matches(&claims));
+        assert!(!rule("c", none_of(&["admin"])).matches(&claims));
+    }
+
+    #[test]
+    fn string_claim_is_not_split_without_separator() {
+        let claims = claims_with(&json!("openid email"));
+        assert!(!rule("c", any_of(&["openid"])).matches(&claims));
+        assert!(rule("c", any_of(&["openid email"])).matches(&claims));
+    }
+
+    #[test]
+    fn number_and_bool_claims_compare_by_canonical_string() {
+        assert!(rule("c", any_of(&["42"])).matches(&claims_with(&json!(42))));
+        assert!(!rule("c", any_of(&["42"])).matches(&claims_with(&json!(42.0))));
+        assert!(rule("c", any_of(&["1.5"])).matches(&claims_with(&json!(1.5))));
+        assert!(rule("c", any_of(&["true"])).matches(&claims_with(&json!(true))));
+        assert!(!rule("c", any_of(&["True"])).matches(&claims_with(&json!(true))));
+    }
+
+    #[test]
+    fn array_claim_has_set_semantics() {
+        let claims = claims_with(&json!(["a", "b", 3]));
+        assert!(rule("c", any_of(&["b"])).matches(&claims));
+        assert!(rule("c", any_of(&["3"])).matches(&claims));
+        assert!(rule("c", all_of(&["a", "b"])).matches(&claims));
+        assert!(!rule("c", all_of(&["a", "z"])).matches(&claims));
+        assert!(rule("c", none_of(&["z"])).matches(&claims));
+        assert!(!rule("c", none_of(&["a"])).matches(&claims));
+    }
+
+    #[test]
+    fn empty_array_matches_nothing_but_exists() {
+        let claims = claims_with(&json!([]));
+        assert!(!rule("c", any_of(&["a"])).matches(&claims));
+        assert!(!rule("c", all_of(&["a"])).matches(&claims));
+        assert!(rule("c", none_of(&["a"])).matches(&claims));
+        assert!(rule("c", ClaimOperator::Exists(true)).matches(&claims));
+        assert!(!rule("c", ClaimOperator::Exists(false)).matches(&claims));
+    }
+
+    #[test]
+    fn object_claim_fails_every_operator_except_exists_true() {
+        let claims = claims_with(&json!({"a": "b"}));
+        assert!(!rule("c", any_of(&["a"])).matches(&claims));
+        assert!(!rule("c", all_of(&["a"])).matches(&claims));
+        assert!(!rule("c", none_of(&["zzz"])).matches(&claims));
+        assert!(rule("c", ClaimOperator::Exists(true)).matches(&claims));
+        assert!(!rule("c", ClaimOperator::Exists(false)).matches(&claims));
+    }
+
+    #[test]
+    fn array_with_non_scalar_element_fails_every_operator_except_exists_true() {
+        for value in [
+            json!(["a", ["b"]]),
+            json!(["a", {"k": "v"}]),
+            json!(["a", null]),
+        ] {
+            let claims = claims_with(&value);
+            assert!(!rule("c", any_of(&["a"])).matches(&claims));
+            assert!(!rule("c", none_of(&["zzz"])).matches(&claims));
+            assert!(rule("c", ClaimOperator::Exists(true)).matches(&claims));
+        }
+    }
+
+    #[test]
+    fn missing_claim_fails_every_operator_except_exists_false() {
+        let claims = json!({ "sub": "u" });
+        assert!(!rule("c", any_of(&["a"])).matches(&claims));
+        assert!(!rule("c", all_of(&["a"])).matches(&claims));
+        assert!(!rule("c", none_of(&["a"])).matches(&claims));
+        assert!(!rule("c", ClaimOperator::Exists(true)).matches(&claims));
+        assert!(rule("c", ClaimOperator::Exists(false)).matches(&claims));
+    }
+
+    #[test]
+    fn null_claim_behaves_like_missing() {
+        let claims = claims_with(&Value::Null);
+        assert!(!rule("c", any_of(&["a"])).matches(&claims));
+        assert!(!rule("c", none_of(&["a"])).matches(&claims));
+        assert!(!rule("c", ClaimOperator::Exists(true)).matches(&claims));
+        assert!(rule("c", ClaimOperator::Exists(false)).matches(&claims));
+    }
+
+    #[test]
+    fn empty_string_claim_exists() {
+        let claims = claims_with(&json!(""));
+        assert!(rule("c", ClaimOperator::Exists(true)).matches(&claims));
+        assert!(!rule("c", any_of(&["a"])).matches(&claims));
+    }
+
+    #[test]
+    fn matching_is_case_sensitive() {
+        let claims = claims_with(&json!("Admin"));
+        assert!(!rule("c", any_of(&["admin"])).matches(&claims));
+        assert!(rule("c", any_of(&["Admin"])).matches(&claims));
+    }
+
+    #[test]
+    fn values_may_contain_commas_and_spaces() {
+        let claims = claims_with(&json!(["a,b", "c d"]));
+        assert!(rule("c", all_of(&["a,b", "c d"])).matches(&claims));
+    }
+
+    // ---- separators ----
+
+    #[test]
+    fn whitespace_separator_splits_string_claim() {
+        let claims = claims_with(&json!("openid  email\tprofile"));
+        let r = |op| rule_sep("c", Separator::Whitespace, op);
+        assert!(r(all_of(&["openid", "email", "profile"])).matches(&claims));
+        assert!(!r(any_of(&["open"])).matches(&claims));
+        // No empty values from the double space.
+        assert!(!r(any_of(&[" "])).matches(&claims));
+    }
+
+    #[test]
+    fn literal_separator_splits_string_claim_and_drops_empty_pieces() {
+        let claims = claims_with(&json!("a,,b,"));
+        let r = rule_sep("c", Separator::Literal(",".into()), all_of(&["a", "b"]));
+        assert!(r.matches(&claims));
+        let r = rule_sep("c", Separator::Literal(",".into()), none_of(&["a,,b,"]));
+        assert!(r.matches(&claims));
+    }
+
+    #[test]
+    fn literal_separator_is_exact_not_whitespace() {
+        let claims = claims_with(&json!("a b\tc"));
+        let r = rule_sep("c", Separator::Literal(" ".into()), all_of(&["a", "b\tc"]));
+        assert!(r.matches(&claims));
+    }
+
+    #[test]
+    fn separator_applies_to_each_string_array_element() {
+        let claims = claims_with(&json!(["openid email", "profile"]));
+        let r = rule_sep(
+            "c",
+            Separator::Whitespace,
+            all_of(&["openid", "email", "profile"]),
+        );
+        assert!(r.matches(&claims));
+    }
+
+    #[test]
+    fn separator_does_not_apply_to_numbers() {
+        let claims = claims_with(&json!(1.5));
+        let r = rule_sep("c", Separator::Literal(".".into()), any_of(&["1.5"]));
+        assert!(r.matches(&claims));
+    }
+
+    // ---- paths ----
+
+    #[test]
+    fn dotted_path_resolves_nested_claims() {
+        let claims = json!({ "realm_access": { "roles": ["admin"] } });
+        assert!(rule("realm_access.roles", any_of(&["admin"])).matches(&claims));
+        assert!(!rule("realm_access.missing", ClaimOperator::Exists(true)).matches(&claims));
+    }
+
+    #[test]
+    fn dotted_path_does_not_index_arrays() {
+        let claims = json!({ "arr": ["x"] });
+        assert!(!rule("arr.0", ClaimOperator::Exists(true)).matches(&claims));
+    }
+
+    #[test]
+    fn fallback_claim_is_used_when_primary_is_absent_or_null() {
+        let r = rule("scope", any_of(&["x"])).or_claim("scp").unwrap();
+        assert!(r.matches(&json!({ "scp": ["x"] })));
+        assert!(r.matches(&json!({ "scope": null, "scp": ["x"] })));
+        // Primary present: fallback is NOT consulted.
+        assert!(!r.matches(&json!({ "scope": "y", "scp": ["x"] })));
+    }
+
+    /// Pins the documented footgun: the first present path decides alone, so a banned
+    /// value in the fallback path is not seen.
+    #[test]
+    fn fallback_is_not_consulted_for_none_of_when_primary_is_present() {
+        let r = rule("scope", none_of(&["banned"])).or_claim("scp").unwrap();
+        assert!(r.matches(&json!({ "scope": "ok", "scp": ["banned"] })));
+        assert!(!r.matches(&json!({ "scp": ["banned"] })));
+    }
+
+    #[test]
+    fn fallback_exists_false_requires_all_paths_absent() {
+        let r = rule("scope", ClaimOperator::Exists(false))
+            .or_claim("scp")
+            .unwrap();
+        assert!(r.matches(&json!({})));
+        assert!(!r.matches(&json!({ "scp": "x" })));
+    }
+
+    #[test]
+    fn navigate_walks_dotted_paths() {
+        let claims = json!({ "a": { "b": 1 } });
+        assert_eq!(navigate(&claims, "a.b"), Some(&json!(1)));
+        assert_eq!(navigate(&claims, "a.c"), None);
+        assert_eq!(navigate(&claims, "a"), Some(&json!({ "b": 1 })));
+    }
+}

--- a/crates/limes/src/error.rs
+++ b/crates/limes/src/error.rs
@@ -11,6 +11,8 @@ pub enum RejectionReason {
     AudienceMismatch,
     /// The `iss` claim matched none of the accepted issuers.
     IssuerMismatch,
+    /// The scope required by `set_scope` is not present.
+    ScopeMissing,
     /// The named required-claim rule did not hold.
     ClaimRuleFailed { rule: String },
     /// None of the configured subject claims is present.
@@ -22,6 +24,7 @@ impl std::fmt::Display for RejectionReason {
         match self {
             Self::AudienceMismatch => f.write_str("audience is not accepted"),
             Self::IssuerMismatch => f.write_str("issuer is not accepted"),
+            Self::ScopeMissing => f.write_str("required scope is missing"),
             Self::ClaimRuleFailed { rule } => write!(f, "required-claim rule `{rule}` failed"),
             Self::SubjectClaimMissing => f.write_str("subject claim is missing"),
         }

--- a/crates/limes/src/error.rs
+++ b/crates/limes/src/error.rs
@@ -1,6 +1,35 @@
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Why a cryptographically verified token was rejected.
+///
+/// Carries names only — never presented or expected claim values — so it is safe to log
+/// and audit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RejectionReason {
+    /// The `aud` claim matched none of the accepted audiences.
+    AudienceMismatch,
+    /// The `iss` claim matched none of the accepted issuers.
+    IssuerMismatch,
+    /// The named required-claim rule did not hold.
+    ClaimRuleFailed { rule: String },
+    /// None of the configured subject claims is present.
+    SubjectClaimMissing,
+}
+
+impl std::fmt::Display for RejectionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AudienceMismatch => f.write_str("audience is not accepted"),
+            Self::IssuerMismatch => f.write_str("issuer is not accepted"),
+            Self::ClaimRuleFailed { rule } => write!(f, "required-claim rule `{rule}` failed"),
+            Self::SubjectClaimMissing => f.write_str("subject claim is missing"),
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Could not parse subject from string: {subject}")]
     InvalidSubject { subject: String },
@@ -12,16 +41,9 @@ pub enum Error {
     KubernetesTokenReviewError(#[source] kube::Error),
     #[error("Authentication failed: {reason}")]
     Unauthenticated { reason: String },
-    #[error("Audience mismatch: expected {expected:?}, got {actual:?}")]
-    AudienceMismatch {
-        expected: Vec<String>,
-        actual: Vec<String>,
-    },
-    #[error("Issuer mismatch: expected {expected:?}, got {actual:?}")]
-    IssuerMismatch {
-        expected: Vec<String>,
-        actual: Vec<String>,
-    },
+    /// A token whose signature verified was rejected by claim validation.
+    #[error("Token rejected: {rejection}")]
+    TokenRejected { rejection: RejectionReason },
     #[error("Failed to parse URL: {0}")]
     UrlParseError(#[from] url::ParseError),
     #[cfg(feature = "jwks")]
@@ -55,6 +77,20 @@ pub enum Error {
 }
 
 impl Error {
+    #[must_use]
+    pub fn rejected(rejection: RejectionReason) -> Self {
+        Self::TokenRejected { rejection }
+    }
+
+    /// The typed reason if this is a [`Error::TokenRejected`].
+    #[must_use]
+    pub fn rejection(&self) -> Option<&RejectionReason> {
+        match self {
+            Self::TokenRejected { rejection } => Some(rejection),
+            _ => None,
+        }
+    }
+
     pub fn unauthenticated(reason: impl Into<String>) -> Self {
         Self::Unauthenticated {
             reason: reason.into(),

--- a/crates/limes/src/error.rs
+++ b/crates/limes/src/error.rs
@@ -19,6 +19,8 @@ pub enum RejectionReason {
     SubjectClaimMissing,
 }
 
+impl std::error::Error for RejectionReason {}
+
 impl std::fmt::Display for RejectionReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -44,9 +46,18 @@ pub enum Error {
     KubernetesTokenReviewError(#[source] kube::Error),
     #[error("Authentication failed: {reason}")]
     Unauthenticated { reason: String },
+    /// A scope passed to `set_scope` that no token could satisfy.
+    #[error("Invalid scope: {source}")]
+    InvalidScope {
+        #[source]
+        source: crate::claims::ClaimRuleError,
+    },
     /// A token whose signature verified was rejected by claim validation.
     #[error("Token rejected: {rejection}")]
-    TokenRejected { rejection: RejectionReason },
+    TokenRejected {
+        #[source]
+        rejection: RejectionReason,
+    },
     #[error("Failed to parse URL: {0}")]
     UrlParseError(#[from] url::ParseError),
     #[cfg(feature = "jwks")]

--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -1,9 +1,11 @@
 //! Validate JWT tokens locally using JWKS keys fetched from a remote server.
 
-use crate::authenticator::SCOPE_CLAIM;
+use crate::authenticator::{SCOPE_CLAIM, SCP_CLAIM};
 use crate::introspect::IntrospectionResult;
 use crate::{
     Authentication, Authenticator, PrincipalType, Subject,
+    claims::{ClaimOperator, ClaimRule, Separator, navigate},
+    error::RejectionReason,
     error::{Error, Result},
 };
 use jsonwebtoken::{Algorithm, DecodingKey, Header, Validation};
@@ -58,7 +60,8 @@ pub struct JWKSWebAuthenticator {
     audiences: Vec<String>,
     client: JwksClient<WebSource>,
     issuers: Vec<String>,
-    scope: Option<String>,
+    scope: Option<ScopeRequirement>,
+    required_claims: Vec<(String, ClaimRule)>,
     config_url: url::Url,
     subject_claim: Vec<String>,
     role_claims: Option<Vec<String>>,
@@ -88,6 +91,7 @@ impl JWKSWebAuthenticator {
             issuers: vec![issuer],
             audiences: Vec::new(),
             scope: None,
+            required_claims: Vec::new(),
             config_url,
             subject_claim: vec![SUBJECT_CLAIM.to_string()],
             role_claims: None,
@@ -126,11 +130,25 @@ impl JWKSWebAuthenticator {
         self
     }
 
-    /// Add a scope to the authenticator.
-    /// If not called, no scope validation is done.
+    /// Require a scope. Calling again replaces the previously required scope.
+    ///
+    /// Read from the `scope` claim, or `scp` if `scope` is absent; a whitespace-delimited
+    /// string or an array of strings. Evaluated before [`with_required_claims`](Self::with_required_claims)
+    /// and reported as rule [`SCOPE_RULE_NAME`]. An empty scope can never be satisfied.
     #[must_use]
     pub fn set_scope(mut self, scope: String) -> Self {
-        self.scope = Some(scope);
+        self.scope = Some(ScopeRequirement::new(scope));
+        self
+    }
+
+    /// Require claim rules, evaluated in order after signature, issuer, audience and scope
+    /// checks. All rules must hold. Names appear only in errors and logs. Calling again appends.
+    #[must_use]
+    pub fn with_required_claims(
+        mut self,
+        rules: impl IntoIterator<Item = (String, ClaimRule)>,
+    ) -> Self {
+        self.required_claims.extend(rules);
         self
     }
 
@@ -303,7 +321,8 @@ impl Authenticator for JWKSWebAuthenticator {
             &key,
             &self.audiences,
             &self.issuers,
-            self.scope.as_deref(),
+            self.scope.as_ref(),
+            &self.required_claims,
         )?;
 
         extract_authentication(
@@ -344,7 +363,8 @@ fn authenticate_jwt(
     key: &JsonWebKey,
     audiences: &[String],
     issuers: &[String],
-    scope: Option<&str>,
+    scope: Option<&ScopeRequirement>,
+    required_claims: &[(String, ClaimRule)],
 ) -> Result<jsonwebtoken::TokenData<serde_json::Value>> {
     let mut validation = if let Some(alg) = key.alg() {
         Validation::new(Algorithm::from_str(alg).map_err(|e| {
@@ -361,13 +381,17 @@ fn authenticate_jwt(
         Validation::new(header.alg)
     };
 
+    // jsonwebtoken checks `aud`/`iss` only when the claim parses; requiring them makes an
+    // absent or malformed claim a rejection instead of a pass.
     if audiences.is_empty() {
         validation.validate_aud = false;
     } else {
         validation.set_audience(audiences);
         validation.validate_aud = true;
+        validation.required_spec_claims.insert("aud".to_string());
     }
     validation.set_issuer(issuers);
+    validation.required_spec_claims.insert("iss".to_string());
 
     let decoding_key = match key {
         JsonWebKey::Rsa(jwk) => DecodingKey::from_rsa_components(jwk.modulus(), jwk.exponent())
@@ -382,20 +406,39 @@ fn authenticate_jwt(
         })?,
     };
 
+    // jsonwebtoken verifies the signature before validating claims, so audience and
+    // issuer failures are rejections of a genuine token; everything else is unverifiable.
     let token_data = jsonwebtoken::decode::<serde_json::Value>(token, &decoding_key, &validation)
-        .map_err(|e| Error::JWTDecodeError {
-        reason: format!("Failed to decode JWT token. {e}"),
+        .map_err(|e| match e.kind() {
+        jsonwebtoken::errors::ErrorKind::InvalidAudience => {
+            Error::rejected(RejectionReason::AudienceMismatch)
+        }
+        jsonwebtoken::errors::ErrorKind::InvalidIssuer => {
+            Error::rejected(RejectionReason::IssuerMismatch)
+        }
+        jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(claim) if claim == "aud" => {
+            Error::rejected(RejectionReason::AudienceMismatch)
+        }
+        jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(claim) if claim == "iss" => {
+            Error::rejected(RejectionReason::IssuerMismatch)
+        }
+        _ => Error::JWTDecodeError {
+            reason: format!("Failed to decode JWT token. {e}"),
+        },
     })?;
 
-    if let Some(required_scope) = scope {
-        let scope_claim = token_data
-            .claims
-            .get(SCOPE_CLAIM)
-            .and_then(serde_json::Value::as_str);
-        if !scope_claim_contains(scope_claim, required_scope) {
-            return Err(Error::unauthenticated(format!(
-                "Token does not contain required scope `{required_scope}`."
-            )));
+    if scope.is_some_and(|scope| !scope.matches(&token_data.claims)) {
+        tracing::debug!(rule = SCOPE_RULE_NAME, "Required scope missing");
+        return Err(Error::rejected(RejectionReason::ClaimRuleFailed {
+            rule: SCOPE_RULE_NAME.to_string(),
+        }));
+    }
+    for (name, rule) in required_claims {
+        if !rule.matches(&token_data.claims) {
+            tracing::debug!(rule = name, "Required-claim rule failed");
+            return Err(Error::rejected(RejectionReason::ClaimRuleFailed {
+                rule: name.clone(),
+            }));
         }
     }
 
@@ -537,9 +580,7 @@ fn get_subject(
             return Ok(subject);
         }
     }
-    Err(Error::unauthenticated(
-        "Could not find the subject claim in the JWT token.".to_string(),
-    ))
+    Err(Error::rejected(RejectionReason::SubjectClaimMissing))
 }
 
 fn parse_human_name(claims: &serde_json::Value) -> Option<String> {
@@ -577,7 +618,15 @@ impl std::fmt::Debug for JWKSWebAuthenticator {
 
         r.field("audiences", &self.audiences)
             .field("issuers", &self.issuers)
-            .field("scope", &self.scope)
+            .field("scope", &self.scope.as_ref().map(ScopeRequirement::rule))
+            .field(
+                "required_claims",
+                &self
+                    .required_claims
+                    .iter()
+                    .map(|(name, rule)| (name.as_str(), rule.claims()))
+                    .collect::<Vec<_>>(),
+            )
             .field("config_url", &self.config_url)
             .field("subject_claim", &self.subject_claim)
             .field("client", &"jwks_client_rs::JwksClient<WebSource>")
@@ -589,16 +638,6 @@ impl std::fmt::Debug for JWKSWebAuthenticator {
 
 fn value_as_string(value: &serde_json::Value) -> Option<String> {
     value.as_str().map(std::string::ToString::to_string)
-}
-
-/// Navigate nested JSON claims using dot-notation (e.g. `resource_access.account.roles`).
-/// Returns the value at the path, or `None` if any segment is absent.
-fn navigate<'a>(claims: &'a serde_json::Value, dot_path: &str) -> Option<&'a serde_json::Value> {
-    let mut current = claims;
-    for part in dot_path.split('.') {
-        current = current.get(part)?;
-    }
-    Some(current)
 }
 
 /// A structurally invalid display-name template — one that can never render for
@@ -768,10 +807,40 @@ impl std::str::FromStr for DisplayNameTemplate {
     }
 }
 
-/// Returns `true` if the space-delimited `scope` claim contains `required`.
-/// Matches without allocating an intermediate collection.
-fn scope_claim_contains(scope_claim: Option<&str>, required: &str) -> bool {
-    scope_claim.is_some_and(|scopes| scopes.split_whitespace().any(|s| s == required))
+/// Name under which a failed [`JWKSWebAuthenticator::set_scope`] requirement is reported.
+pub const SCOPE_RULE_NAME: &str = "scope";
+
+/// The `set_scope` requirement: a rule on `scope`/`scp`, or unsatisfiable for an empty scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ScopeRequirement {
+    Rule(ClaimRule),
+    Unsatisfiable,
+}
+
+impl ScopeRequirement {
+    fn new(scope: String) -> Self {
+        ClaimRule::new(
+            SCOPE_CLAIM,
+            Some(Separator::Whitespace),
+            ClaimOperator::AllOf(std::collections::HashSet::from([scope])),
+        )
+        .and_then(|r| r.or_claim(SCP_CLAIM))
+        .map_or(Self::Unsatisfiable, Self::Rule)
+    }
+
+    fn matches(&self, claims: &serde_json::Value) -> bool {
+        match self {
+            Self::Rule(rule) => rule.matches(claims),
+            Self::Unsatisfiable => false,
+        }
+    }
+
+    fn rule(&self) -> Option<&ClaimRule> {
+        match self {
+            Self::Rule(rule) => Some(rule),
+            Self::Unsatisfiable => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -780,26 +849,328 @@ mod test {
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
 
-    #[test]
-    fn test_scope_claim_contains_multi() {
-        assert!(scope_claim_contains(
-            Some("openid profile email"),
-            "profile"
-        ));
-        assert!(!scope_claim_contains(Some("openid profile email"), "admin"));
+    // ---- signed-token fixtures ----
+
+    fn ed25519_fixture() -> (jsonwebtoken::EncodingKey, JsonWebKey) {
+        use base64::Engine as _;
+        let key_pair = aws_lc_rs::signature::Ed25519KeyPair::generate().unwrap();
+        let pkcs8 = key_pair.to_pkcs8().unwrap();
+        let encoding_key = jsonwebtoken::EncodingKey::from_ed_der(pkcs8.as_ref());
+        let x = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(aws_lc_rs::signature::KeyPair::public_key(&key_pair).as_ref());
+        let jwk: JsonWebKey = serde_json::from_value(serde_json::json!({
+            "kty": "OKP", "crv": "Ed25519", "alg": "EdDSA", "kid": "k1", "x": x
+        }))
+        .unwrap();
+        (encoding_key, jwk)
+    }
+
+    fn sign(key: &jsonwebtoken::EncodingKey, mut claims: serde_json::Value) -> (String, Header) {
+        let exp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        claims["exp"] = serde_json::json!(exp);
+        let mut header = Header::new(Algorithm::EdDSA);
+        header.kid = Some("k1".to_string());
+        let token = jsonwebtoken::encode(&header, &claims, key).unwrap();
+        (token, header)
+    }
+
+    const ISS: &str = "https://idp.example.com";
+    const AUD: &str = "lakekeeper";
+
+    fn org_rule(org: &str) -> (String, ClaimRule) {
+        (
+            "org".to_string(),
+            ClaimRule::new(
+                "organizations",
+                None,
+                ClaimOperator::AnyOf(HashSet::from([org.to_string()])),
+            )
+            .unwrap(),
+        )
+    }
+
+    fn verify(
+        key: &JsonWebKey,
+        token: &str,
+        header: &Header,
+        rules: &[(String, ClaimRule)],
+    ) -> Result<jsonwebtoken::TokenData<serde_json::Value>> {
+        verify_with_scope(key, token, header, None, rules)
+    }
+
+    fn verify_with_scope(
+        key: &JsonWebKey,
+        token: &str,
+        header: &Header,
+        scope: Option<&ScopeRequirement>,
+        rules: &[(String, ClaimRule)],
+    ) -> Result<jsonwebtoken::TokenData<serde_json::Value>> {
+        authenticate_jwt(
+            token,
+            header,
+            key,
+            &[AUD.to_string()],
+            &[ISS.to_string()],
+            scope,
+            rules,
+        )
+    }
+
+    fn org_failed() -> Option<RejectionReason> {
+        Some(RejectionReason::ClaimRuleFailed {
+            rule: "org".to_string(),
+        })
     }
 
     #[test]
-    fn test_scope_claim_contains_single() {
-        assert!(scope_claim_contains(Some("openid"), "openid"));
-        // Must match a whole scope, not a prefix.
-        assert!(!scope_claim_contains(Some("openid"), "open"));
+    fn test_authenticate_jwt_accepts_token_satisfying_rules() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "organizations": ["tenant-a"] }),
+        );
+        let data = verify(&jwk, &token, &header, &[org_rule("tenant-a")]).unwrap();
+        assert_eq!(data.claims["sub"], "u");
     }
 
     #[test]
-    fn test_scope_claim_contains_absent() {
-        assert!(!scope_claim_contains(None, "openid"));
-        assert!(!scope_claim_contains(Some(""), "openid"));
+    fn test_authenticate_jwt_rejects_failed_rule_with_typed_reason_and_no_values() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "organizations": ["tenant-b"] }),
+        );
+        let err = verify(&jwk, &token, &header, &[org_rule("tenant-a")]).unwrap_err();
+        assert_eq!(err.rejection(), org_failed().as_ref());
+        let rendered = format!("{err} {err:?}");
+        assert!(!rendered.contains("tenant-a"), "{rendered}");
+        assert!(!rendered.contains("organizations"), "{rendered}");
+        assert!(!rendered.contains("tenant-b"), "{rendered}");
+    }
+
+    #[test]
+    fn test_authenticate_jwt_missing_claim_fails_closed() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u" }),
+        );
+        let err = verify(&jwk, &token, &header, &[org_rule("tenant-a")]).unwrap_err();
+        assert_eq!(err.rejection(), org_failed().as_ref());
+    }
+
+    #[test]
+    fn test_authenticate_jwt_reports_first_failing_rule_in_order() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "organizations": ["tenant-a"] }),
+        );
+        let scope = (
+            "scopes".to_string(),
+            ClaimRule::new(
+                "scope",
+                Some(Separator::Whitespace),
+                ClaimOperator::AllOf(HashSet::from(["openid".to_string()])),
+            )
+            .unwrap(),
+        );
+        let err = verify(&jwk, &token, &header, &[org_rule("tenant-a"), scope]).unwrap_err();
+        assert_eq!(
+            err.rejection(),
+            Some(&RejectionReason::ClaimRuleFailed {
+                rule: "scopes".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_authenticate_jwt_rejects_token_without_aud_when_audience_configured() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(&enc, serde_json::json!({ "iss": ISS, "sub": "u" }));
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(err.rejection(), Some(&RejectionReason::AudienceMismatch));
+    }
+
+    #[test]
+    fn test_authenticate_jwt_rejects_token_with_malformed_aud() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": 42, "sub": "u" }),
+        );
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(err.rejection(), Some(&RejectionReason::AudienceMismatch));
+    }
+
+    #[test]
+    fn test_authenticate_jwt_rejects_token_without_iss() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(&enc, serde_json::json!({ "aud": AUD, "sub": "u" }));
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(err.rejection(), Some(&RejectionReason::IssuerMismatch));
+    }
+
+    #[test]
+    fn test_authenticate_jwt_accepts_token_without_aud_when_no_audience_configured() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(&enc, serde_json::json!({ "iss": ISS, "sub": "u" }));
+        let data =
+            authenticate_jwt(&token, &header, &jwk, &[], &[ISS.to_string()], None, &[]).unwrap();
+        assert_eq!(data.claims["sub"], "u");
+    }
+
+    #[test]
+    fn test_authenticate_jwt_classifies_audience_mismatch_without_values() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": "someone-else", "sub": "u" }),
+        );
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(err.rejection(), Some(&RejectionReason::AudienceMismatch));
+        let rendered = format!("{err} {err:?}");
+        assert!(!rendered.contains("someone-else"), "{rendered}");
+        assert!(!rendered.contains(AUD), "{rendered}");
+    }
+
+    #[test]
+    fn test_authenticate_jwt_classifies_issuer_mismatch() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": "https://evil.example.com", "aud": AUD, "sub": "u" }),
+        );
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(err.rejection(), Some(&RejectionReason::IssuerMismatch));
+    }
+
+    #[test]
+    fn test_authenticate_jwt_bad_signature_is_not_a_rejection() {
+        let (enc, _) = ed25519_fixture();
+        let (_, other_jwk) = ed25519_fixture();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u" }),
+        );
+        let err = verify(&other_jwk, &token, &header, &[]).unwrap_err();
+        assert!(matches!(err, Error::JWTDecodeError { .. }), "{err:?}");
+        assert_eq!(err.rejection(), None);
+    }
+
+    #[test]
+    fn test_authenticate_jwt_expired_is_not_a_rejection() {
+        let (enc, jwk) = ed25519_fixture();
+        let mut header = Header::new(Algorithm::EdDSA);
+        header.kid = Some("k1".to_string());
+        let token = jsonwebtoken::encode(
+            &header,
+            &serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "exp": 1 }),
+            &enc,
+        )
+        .unwrap();
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert!(matches!(err, Error::JWTDecodeError { .. }), "{err:?}");
+    }
+
+    // ---- scope sugar ----
+
+    #[test]
+    fn test_scope_requirement_is_a_rule_with_scp_fallback() {
+        assert_eq!(
+            ScopeRequirement::new("openid".to_string()),
+            ScopeRequirement::Rule(
+                ClaimRule::new(
+                    SCOPE_CLAIM,
+                    Some(Separator::Whitespace),
+                    ClaimOperator::AllOf(HashSet::from(["openid".to_string()])),
+                )
+                .unwrap()
+                .or_claim("scp")
+                .unwrap()
+            )
+        );
+        assert_eq!(
+            ScopeRequirement::new(String::new()),
+            ScopeRequirement::Unsatisfiable
+        );
+    }
+
+    #[test]
+    fn test_scope_requirement_matches_previous_scope_check_cases() {
+        let scope = ScopeRequirement::new("profile".to_string());
+        let ok = |v: serde_json::Value| scope.matches(&serde_json::json!({ "scope": v }));
+        assert!(ok(serde_json::json!("openid profile email")));
+        assert!(ok(serde_json::json!("openid  profile\temail")));
+        assert!(ok(serde_json::json!("profile")));
+        assert!(!ok(serde_json::json!("openid email")));
+        // Whole scope, not a prefix.
+        assert!(!ok(serde_json::json!("profiles")));
+        assert!(!ok(serde_json::json!("")));
+        assert!(!scope.matches(&serde_json::json!({ "sub": "u" })));
+        // New: array-shaped scope claims and the `scp` claim.
+        assert!(ok(serde_json::json!(["openid", "profile"])));
+        assert!(scope.matches(&serde_json::json!({ "scp": ["profile"] })));
+        assert!(scope.matches(&serde_json::json!({ "scp": "openid profile" })));
+    }
+
+    fn scope_failed() -> Option<RejectionReason> {
+        Some(RejectionReason::ClaimRuleFailed {
+            rule: SCOPE_RULE_NAME.to_string(),
+        })
+    }
+
+    #[test]
+    fn test_empty_scope_rejects_every_token() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "scope": "openid" }),
+        );
+        let scope = ScopeRequirement::new(String::new());
+        let err = verify_with_scope(&jwk, &token, &header, Some(&scope), &[]).unwrap_err();
+        assert_eq!(err.rejection(), scope_failed().as_ref());
+    }
+
+    #[test]
+    fn test_scope_failure_is_reported_before_required_claims() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "scope": "openid" }),
+        );
+        let scope = ScopeRequirement::new("admin".to_string());
+        let err =
+            verify_with_scope(&jwk, &token, &header, Some(&scope), &[org_rule("x")]).unwrap_err();
+        assert_eq!(err.rejection(), scope_failed().as_ref());
+    }
+
+    #[test]
+    fn test_caller_rule_named_scope_is_kept_alongside_set_scope() {
+        // A caller rule may use any name, including the scope requirement's report name.
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "scope": "admin" }),
+        );
+        let scope = ScopeRequirement::new("admin".to_string());
+        let caller = (SCOPE_RULE_NAME.to_string(), org_rule("tenant-a").1);
+        let err = verify_with_scope(&jwk, &token, &header, Some(&scope), &[caller]).unwrap_err();
+        assert_eq!(err.rejection(), scope_failed().as_ref());
+    }
+
+    #[test]
+    fn test_get_subject_missing_is_typed_rejection() {
+        let token_data = jsonwebtoken::TokenData {
+            header: Header::new(Algorithm::EdDSA),
+            claims: serde_json::json!({ "iss": ISS }),
+        };
+        let err = get_subject(&token_data, &["sub".to_string()]).unwrap_err();
+        assert_eq!(err.rejection(), Some(&RejectionReason::SubjectClaimMissing));
     }
 
     #[test]

--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -66,7 +66,7 @@ struct Inner {
     audiences: Vec<String>,
     client: JwksClient<WebSource>,
     issuers: Vec<String>,
-    scope: Option<ScopeRequirement>,
+    scope: Option<ScopeRule>,
     required_claims: Vec<(String, ClaimRule)>,
     config_url: url::Url,
     subject_claim: Vec<String>,
@@ -143,19 +143,25 @@ impl JWKSWebAuthenticator {
     /// Require a scope. Calling again replaces the previously required scope.
     ///
     /// Read from the `scope` claim, or `scp` if `scope` is absent; a whitespace-delimited
-    /// string or an array of strings. Evaluated before
+    /// string or an array of strings, whose values must be strings. Evaluated before
     /// [`with_required_claims`](Self::with_required_claims); a failure is reported as
-    /// [`RejectionReason::ScopeMissing`]. A single scope is required: an empty scope, or
-    /// one containing whitespace, can never be satisfied.
-    #[must_use]
-    pub fn set_scope(mut self, scope: String) -> Self {
-        std::sync::Arc::make_mut(&mut self.inner).scope = Some(ScopeRequirement::new(scope));
-        self
+    /// [`RejectionReason::ScopeMissing`].
+    ///
+    /// # Errors
+    /// If `scope` is empty or contains whitespace — such a scope could never be satisfied.
+    pub fn set_scope(mut self, scope: String) -> Result<Self> {
+        std::sync::Arc::make_mut(&mut self.inner).scope = Some(ScopeRule::new(scope)?);
+        Ok(self)
     }
 
     /// Require claim rules, evaluated in order after signature, issuer, audience and scope
     /// checks. All rules must hold. Names appear only in errors and logs. Calling again
     /// replaces the previously set rules.
+    ///
+    /// Audience validation accepts a token whose `aud` merely intersects the accepted set —
+    /// a token minted for several audiences authenticates here too. To bind tokens to one
+    /// client, additionally require the authorized party:
+    /// `ClaimRule::any_of("azp", [client_id])`.
     #[must_use]
     pub fn with_required_claims(
         mut self,
@@ -317,18 +323,22 @@ impl Authenticator for JWKSWebAuthenticator {
         let key_id = header.kid.as_deref().ok_or_else(|| Error::JWTDecodeError {
             reason: "Token does not contain a key id".to_string(),
         })?;
-        let key = self
-            .inner
-            .client
-            .get_opt(key_id)
-            .await
-            .map_err(|e| Error::RefreshOpenIDWellKnownConfigError {
-                url: self.inner.config_url.to_string(),
-                reason: e.to_string(),
-            })?
-            .ok_or_else(|| {
-                Error::unauthenticated(format!("Key id `{key_id}` not found in JWKS."))
-            })?;
+        let key = self.inner.client.get(key_id).await.map_err(|e| {
+            // `jwks_client_rs` keeps its error enum private, so `KeyNotFound` — the token
+            // names a key the IdP does not publish — is only recognizable by its message
+            // ("Cannot find key for key_id: …"). That case is an authentication failure of
+            // this token, not an IdP problem; the attacker-controlled key id is not
+            // reproduced in the error. A future message change degrades only the error
+            // classification, never admits a token.
+            if e.to_string().starts_with("Cannot find key for key_id") {
+                Error::unauthenticated("Token key id not found in JWKS.")
+            } else {
+                Error::RefreshOpenIDWellKnownConfigError {
+                    url: self.inner.config_url.to_string(),
+                    reason: e.to_string(),
+                }
+            }
+        })?;
         let token_data = authenticate_jwt(
             token,
             header,
@@ -379,7 +389,7 @@ fn authenticate_jwt(
     key: &JsonWebKey,
     audiences: &[String],
     issuers: &[String],
-    scope: Option<&ScopeRequirement>,
+    scope: Option<&ScopeRule>,
     required_claims: &[(String, ClaimRule)],
 ) -> Result<jsonwebtoken::TokenData<serde_json::Value>> {
     let mut validation = if let Some(alg) = key.alg() {
@@ -408,6 +418,9 @@ fn authenticate_jwt(
     }
     validation.set_issuer(issuers);
     validation.required_spec_claims.insert("iss".to_string());
+    // `exp` is validated by default; `nbf` (RFC 7519 §4.1.5) is opt-in. A token before its
+    // `nbf` is not yet valid. An absent `nbf` stays acceptable.
+    validation.validate_nbf = true;
 
     let decoding_key = match key {
         JsonWebKey::Rsa(jwk) => DecodingKey::from_rsa_components(jwk.modulus(), jwk.exponent())
@@ -636,10 +649,7 @@ impl std::fmt::Debug for JWKSWebAuthenticator {
 
         r.field("audiences", &self.inner.audiences)
             .field("issuers", &self.inner.issuers)
-            .field(
-                "scope",
-                &self.inner.scope.as_ref().map(ScopeRequirement::rule),
-            )
+            .field("scope", &self.inner.scope.as_ref().map(|s| s.0.claims()))
             .field(
                 "required_claims",
                 &self
@@ -829,37 +839,29 @@ impl std::str::FromStr for DisplayNameTemplate {
     }
 }
 
-/// The `set_scope` requirement: a rule on `scope`/`scp`, or unsatisfiable when the scope is
-/// empty or contains whitespace (a whitespace-split value can never equal it).
+/// The `set_scope` requirement: a whitespace-split `all_of` rule on `scope`/`scp`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum ScopeRequirement {
-    Rule(ClaimRule),
-    Unsatisfiable,
-}
+struct ScopeRule(ClaimRule);
 
-impl ScopeRequirement {
-    fn new(scope: String) -> Self {
+impl ScopeRule {
+    fn new(scope: String) -> Result<Self> {
         ClaimRule::new(
             SCOPE_CLAIM,
             Some(Separator::Whitespace),
             ClaimOperator::AllOf(std::collections::HashSet::from([scope])),
         )
         .and_then(|r| r.or_claim(SCP_CLAIM))
-        .map_or(Self::Unsatisfiable, Self::Rule)
+        .map(Self)
+        .map_err(|e| Error::InvalidScope { source: e })
     }
 
+    /// Scopes are strings: a claim holding numbers or booleans is malformed and never
+    /// satisfies the requirement, matching [`Authentication::scopes`].
     fn matches(&self, claims: &serde_json::Value) -> bool {
-        match self {
-            Self::Rule(rule) => rule.matches(claims),
-            Self::Unsatisfiable => false,
-        }
-    }
-
-    fn rule(&self) -> Option<&ClaimRule> {
-        match self {
-            Self::Rule(rule) => Some(rule),
-            Self::Unsatisfiable => None,
-        }
+        crate::authenticator::scope_claim(claims)
+            .and_then(crate::claims::strings)
+            .is_some()
+            && self.0.matches(claims)
     }
 }
 
@@ -926,7 +928,7 @@ mod test {
         key: &JsonWebKey,
         token: &str,
         header: &Header,
-        scope: Option<&ScopeRequirement>,
+        scope: Option<&ScopeRule>,
         rules: &[(String, ClaimRule)],
     ) -> Result<jsonwebtoken::TokenData<serde_json::Value>> {
         authenticate_jwt(
@@ -1076,6 +1078,42 @@ mod test {
     }
 
     #[test]
+    fn test_authenticate_jwt_rejects_token_before_nbf() {
+        let (enc, jwk) = ed25519_fixture();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "nbf": now + 3600 }),
+        );
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Failed to decode JWT Token. Failed to decode JWT token. ImmatureSignature"
+        );
+        assert_eq!(err.rejection(), None);
+    }
+
+    #[test]
+    fn test_authenticate_jwt_accepts_past_nbf_and_absent_nbf() {
+        let (enc, jwk) = ed25519_fixture();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        for claims in [
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "nbf": now - 60 }),
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u" }),
+        ] {
+            let (token, header) = sign(&enc, claims);
+            let data = verify(&jwk, &token, &header, &[]).unwrap();
+            assert_eq!(data.claims["sub"], "u");
+        }
+    }
+
+    #[test]
     fn test_authenticate_jwt_uses_token_alg_when_jwk_has_none() {
         use base64::Engine as _;
         let key_pair = aws_lc_rs::signature::Ed25519KeyPair::generate().unwrap();
@@ -1118,10 +1156,10 @@ mod test {
     // ---- scope sugar ----
 
     #[test]
-    fn test_scope_requirement_is_a_rule_with_scp_fallback() {
+    fn test_scope_rule_is_a_whitespace_all_of_with_scp_fallback() {
         assert_eq!(
-            ScopeRequirement::new("openid".to_string()),
-            ScopeRequirement::Rule(
+            ScopeRule::new("openid".to_string()).unwrap(),
+            ScopeRule(
                 ClaimRule::new(
                     SCOPE_CLAIM,
                     Some(Separator::Whitespace),
@@ -1132,19 +1170,33 @@ mod test {
                 .unwrap()
             )
         );
+    }
+
+    /// A scope that no token could ever satisfy is a configuration error, rejected at
+    /// construction like the equivalent required-claim rule.
+    #[test]
+    fn test_unsatisfiable_scopes_are_rejected_at_construction() {
         assert_eq!(
-            ScopeRequirement::new(String::new()),
-            ScopeRequirement::Unsatisfiable
+            ScopeRule::new(String::new()).unwrap_err().to_string(),
+            "Invalid scope: all_of must not contain empty strings"
         );
         assert_eq!(
-            ScopeRequirement::new("read write".to_string()),
-            ScopeRequirement::Unsatisfiable
+            ScopeRule::new("read write".to_string())
+                .unwrap_err()
+                .to_string(),
+            "Invalid scope: all_of value `read write` contains the separator"
+        );
+        assert_eq!(
+            ScopeRule::new(" admin".to_string())
+                .unwrap_err()
+                .to_string(),
+            "Invalid scope: all_of value ` admin` contains the separator"
         );
     }
 
     #[test]
-    fn test_scope_requirement_matches_previous_scope_check_cases() {
-        let scope = ScopeRequirement::new("profile".to_string());
+    fn test_scope_rule_matches_previous_scope_check_cases() {
+        let scope = ScopeRule::new("profile".to_string()).unwrap();
         let ok = |v: serde_json::Value| scope.matches(&serde_json::json!({ "scope": v }));
         assert!(ok(serde_json::json!("openid profile email")));
         assert!(ok(serde_json::json!("openid  profile\temail")));
@@ -1161,15 +1213,13 @@ mod test {
     }
 
     #[test]
-    fn test_empty_scope_rejects_every_token() {
-        let (enc, jwk) = ed25519_fixture();
-        let (token, header) = sign(
-            &enc,
-            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "scope": "openid" }),
-        );
-        let scope = ScopeRequirement::new(String::new());
-        let err = verify_with_scope(&jwk, &token, &header, Some(&scope), &[]).unwrap_err();
-        assert_eq!(err.rejection(), Some(&RejectionReason::ScopeMissing));
+    fn test_scope_rule_rejects_non_string_scope_values() {
+        let scope = ScopeRule::new("42".to_string()).unwrap();
+        assert!(!scope.matches(&serde_json::json!({ "scope": 42 })));
+        assert!(scope.matches(&serde_json::json!({ "scope": ["42"] })));
+        let scope = ScopeRule::new("admin".to_string()).unwrap();
+        assert!(!scope.matches(&serde_json::json!({ "scope": ["admin", 42] })));
+        assert!(!scope.matches(&serde_json::json!({ "scope": ["admin", true] })));
     }
 
     #[test]
@@ -1179,7 +1229,7 @@ mod test {
             &enc,
             serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "scope": "openid" }),
         );
-        let scope = ScopeRequirement::new("admin".to_string());
+        let scope = ScopeRule::new("admin".to_string()).unwrap();
         let err =
             verify_with_scope(&jwk, &token, &header, Some(&scope), &[org_rule("x")]).unwrap_err();
         assert_eq!(err.rejection(), Some(&RejectionReason::ScopeMissing));
@@ -1188,7 +1238,7 @@ mod test {
     #[test]
     fn test_scope_and_caller_rule_failures_are_distinguishable() {
         let (enc, jwk) = ed25519_fixture();
-        let scope = ScopeRequirement::new("admin".to_string());
+        let scope = ScopeRule::new("admin".to_string()).unwrap();
         let caller = ("scope".to_string(), org_rule("tenant-a").1);
         // Scope satisfied, caller rule fails.
         let (token, header) = sign(
@@ -1285,7 +1335,7 @@ mod test {
         let clone = authenticator.clone();
         assert!(std::sync::Arc::ptr_eq(&authenticator.inner, &clone.inner));
         // Configuring a clone does not affect the original.
-        let changed = clone.set_scope("x".to_string());
+        let changed = clone.set_scope("x".to_string()).unwrap();
         assert!(authenticator.inner.scope.is_none());
         assert!(changed.inner.scope.is_some());
         server.abort();

--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -56,6 +56,12 @@ const AUD_CLAIM: &str = "aud";
 ///   claim (`Human`), an `app_displayname`/`client_id` claim (`Application`); `None` if undetermined.
 ///
 pub struct JWKSWebAuthenticator {
+    // Shared so that cloning the authenticator per request is a refcount bump.
+    inner: std::sync::Arc<Inner>,
+}
+
+#[derive(Clone)]
+struct Inner {
     idp_id: Option<String>,
     audiences: Vec<String>,
     client: JwksClient<WebSource>,
@@ -86,16 +92,18 @@ impl JWKSWebAuthenticator {
         let (client, issuer, config_url) =
             JWKSWebAuthenticator::initialize_client(issuer_url, ttl).await?;
         Ok(Self {
-            idp_id: None,
-            client,
-            issuers: vec![issuer],
-            audiences: Vec::new(),
-            scope: None,
-            required_claims: Vec::new(),
-            config_url,
-            subject_claim: vec![SUBJECT_CLAIM.to_string()],
-            role_claims: None,
-            display_name_template: None,
+            inner: std::sync::Arc::new(Inner {
+                idp_id: None,
+                client,
+                issuers: vec![issuer],
+                audiences: Vec::new(),
+                scope: None,
+                required_claims: Vec::new(),
+                config_url,
+                subject_claim: vec![SUBJECT_CLAIM.to_string()],
+                role_claims: None,
+                display_name_template: None,
+            }),
         })
     }
 
@@ -104,7 +112,7 @@ impl JWKSWebAuthenticator {
     #[must_use]
     pub fn set_idp_id(mut self, idp_id: &str) -> Self {
         if !idp_id.is_empty() {
-            self.idp_id = Some(idp_id.to_string());
+            std::sync::Arc::make_mut(&mut self.inner).idp_id = Some(idp_id.to_string());
         }
         self
     }
@@ -113,7 +121,7 @@ impl JWKSWebAuthenticator {
     /// If empty / not called, no audience validation is done.
     #[must_use]
     pub fn set_accepted_audiences(mut self, audiences: Vec<String>) -> Self {
-        self.audiences = audiences;
+        std::sync::Arc::make_mut(&mut self.inner).audiences = audiences;
         self
     }
 
@@ -124,31 +132,36 @@ impl JWKSWebAuthenticator {
         // Make sure to not add duplicates
         let additional_issuers: Vec<_> = additional_issuers
             .into_iter()
-            .filter(|issuer| !self.issuers.contains(issuer))
+            .filter(|issuer| !self.inner.issuers.contains(issuer))
             .collect();
-        self.issuers.extend(additional_issuers);
+        std::sync::Arc::make_mut(&mut self.inner)
+            .issuers
+            .extend(additional_issuers);
         self
     }
 
     /// Require a scope. Calling again replaces the previously required scope.
     ///
     /// Read from the `scope` claim, or `scp` if `scope` is absent; a whitespace-delimited
-    /// string or an array of strings. Evaluated before [`with_required_claims`](Self::with_required_claims)
-    /// and reported as rule [`SCOPE_RULE_NAME`]. An empty scope can never be satisfied.
+    /// string or an array of strings. Evaluated before
+    /// [`with_required_claims`](Self::with_required_claims); a failure is reported as
+    /// [`RejectionReason::ScopeMissing`]. A single scope is required: an empty scope, or
+    /// one containing whitespace, can never be satisfied.
     #[must_use]
     pub fn set_scope(mut self, scope: String) -> Self {
-        self.scope = Some(ScopeRequirement::new(scope));
+        std::sync::Arc::make_mut(&mut self.inner).scope = Some(ScopeRequirement::new(scope));
         self
     }
 
     /// Require claim rules, evaluated in order after signature, issuer, audience and scope
-    /// checks. All rules must hold. Names appear only in errors and logs. Calling again appends.
+    /// checks. All rules must hold. Names appear only in errors and logs. Calling again
+    /// replaces the previously set rules.
     #[must_use]
     pub fn with_required_claims(
         mut self,
         rules: impl IntoIterator<Item = (String, ClaimRule)>,
     ) -> Self {
-        self.required_claims.extend(rules);
+        std::sync::Arc::make_mut(&mut self.inner).required_claims = rules.into_iter().collect();
         self
     }
 
@@ -156,7 +169,7 @@ impl JWKSWebAuthenticator {
     /// If `None`, the `sub` claim will be used.
     #[must_use]
     pub fn with_subject_claim(mut self, subject_claim: String) -> Self {
-        self.subject_claim = vec![subject_claim];
+        std::sync::Arc::make_mut(&mut self.inner).subject_claim = vec![subject_claim];
         self
     }
 
@@ -172,7 +185,7 @@ impl JWKSWebAuthenticator {
         // For entra-id most applications that
         // interact with other applications should prefer the `oid` claim over the `sub` claim.
         if !subject_claims.is_empty() {
-            self.subject_claim = subject_claims;
+            std::sync::Arc::make_mut(&mut self.inner).subject_claim = subject_claims;
         }
         self
     }
@@ -200,9 +213,9 @@ impl JWKSWebAuthenticator {
     pub fn with_role_claims(mut self, role_claims: Vec<String>) -> Self {
         let filtered: Vec<String> = role_claims.into_iter().filter(|s| !s.is_empty()).collect();
         if filtered.is_empty() {
-            self.role_claims = None;
+            std::sync::Arc::make_mut(&mut self.inner).role_claims = None;
         } else {
-            self.role_claims = Some(filtered);
+            std::sync::Arc::make_mut(&mut self.inner).role_claims = Some(filtered);
         }
         self
     }
@@ -225,7 +238,7 @@ impl JWKSWebAuthenticator {
     /// `DisplayNameTemplate::parse("Service Account {email}")`.
     #[must_use]
     pub fn with_display_name_template(mut self, template: DisplayNameTemplate) -> Self {
-        self.display_name_template = Some(template);
+        std::sync::Arc::make_mut(&mut self.inner).display_name_template = Some(template);
         self
     }
 
@@ -305,11 +318,12 @@ impl Authenticator for JWKSWebAuthenticator {
             reason: "Token does not contain a key id".to_string(),
         })?;
         let key = self
+            .inner
             .client
             .get_opt(key_id)
             .await
             .map_err(|e| Error::RefreshOpenIDWellKnownConfigError {
-                url: self.config_url.to_string(),
+                url: self.inner.config_url.to_string(),
                 reason: e.to_string(),
             })?
             .ok_or_else(|| {
@@ -319,23 +333,23 @@ impl Authenticator for JWKSWebAuthenticator {
             token,
             header,
             &key,
-            &self.audiences,
-            &self.issuers,
-            self.scope.as_ref(),
-            &self.required_claims,
+            &self.inner.audiences,
+            &self.inner.issuers,
+            self.inner.scope.as_ref(),
+            &self.inner.required_claims,
         )?;
 
         extract_authentication(
             self.idp_id().map(String::as_str),
             token_data,
-            &self.subject_claim,
-            self.role_claims.as_deref(),
-            self.display_name_template.as_ref(),
+            &self.inner.subject_claim,
+            self.inner.role_claims.as_deref(),
+            self.inner.display_name_template.as_ref(),
         )
     }
 
     fn idp_id(&self) -> Option<&String> {
-        self.idp_id.as_ref()
+        self.inner.idp_id.as_ref()
     }
 
     fn can_handle_token(&self, token: &str, introspection_result: &IntrospectionResult) -> bool {
@@ -349,8 +363,10 @@ impl Authenticator for JWKSWebAuthenticator {
                 aud,
                 header: _,
             } => {
-                (self.issuers.is_empty() || self.issuers.iter().any(|i| iss.contains(i)))
-                    && (self.audiences.is_empty() || self.audiences.iter().any(|a| aud.contains(a)))
+                (self.inner.issuers.is_empty()
+                    || self.inner.issuers.iter().any(|i| iss.contains(i)))
+                    && (self.inner.audiences.is_empty()
+                        || self.inner.audiences.iter().any(|a| aud.contains(a)))
             }
             IntrospectionResult::Unknown => false,
         }
@@ -411,15 +427,19 @@ fn authenticate_jwt(
     let token_data = jsonwebtoken::decode::<serde_json::Value>(token, &decoding_key, &validation)
         .map_err(|e| match e.kind() {
         jsonwebtoken::errors::ErrorKind::InvalidAudience => {
+            tracing::debug!(accepted_audiences = ?audiences, "Token audience rejected: {e}");
             Error::rejected(RejectionReason::AudienceMismatch)
         }
         jsonwebtoken::errors::ErrorKind::InvalidIssuer => {
+            tracing::debug!(accepted_issuers = ?issuers, "Token issuer rejected: {e}");
             Error::rejected(RejectionReason::IssuerMismatch)
         }
         jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(claim) if claim == "aud" => {
+            tracing::debug!(accepted_audiences = ?audiences, "Token audience rejected: {e}");
             Error::rejected(RejectionReason::AudienceMismatch)
         }
         jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(claim) if claim == "iss" => {
+            tracing::debug!(accepted_issuers = ?issuers, "Token issuer rejected: {e}");
             Error::rejected(RejectionReason::IssuerMismatch)
         }
         _ => Error::JWTDecodeError {
@@ -428,10 +448,8 @@ fn authenticate_jwt(
     })?;
 
     if scope.is_some_and(|scope| !scope.matches(&token_data.claims)) {
-        tracing::debug!(rule = SCOPE_RULE_NAME, "Required scope missing");
-        return Err(Error::rejected(RejectionReason::ClaimRuleFailed {
-            rule: SCOPE_RULE_NAME.to_string(),
-        }));
+        tracing::debug!("Required scope missing");
+        return Err(Error::rejected(RejectionReason::ScopeMissing));
     }
     for (name, rule) in required_claims {
         if !rule.matches(&token_data.claims) {
@@ -614,24 +632,28 @@ impl std::fmt::Debug for JWKSWebAuthenticator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut r = f.debug_struct("JWKSWebAuthenticator");
 
-        let r = r.field("idp_id", &self.idp_id);
+        let r = r.field("idp_id", &self.inner.idp_id);
 
-        r.field("audiences", &self.audiences)
-            .field("issuers", &self.issuers)
-            .field("scope", &self.scope.as_ref().map(ScopeRequirement::rule))
+        r.field("audiences", &self.inner.audiences)
+            .field("issuers", &self.inner.issuers)
+            .field(
+                "scope",
+                &self.inner.scope.as_ref().map(ScopeRequirement::rule),
+            )
             .field(
                 "required_claims",
                 &self
+                    .inner
                     .required_claims
                     .iter()
                     .map(|(name, rule)| (name.as_str(), rule.claims()))
                     .collect::<Vec<_>>(),
             )
-            .field("config_url", &self.config_url)
-            .field("subject_claim", &self.subject_claim)
+            .field("config_url", &self.inner.config_url)
+            .field("subject_claim", &self.inner.subject_claim)
             .field("client", &"jwks_client_rs::JwksClient<WebSource>")
-            .field("role_claims", &self.role_claims)
-            .field("display_name_template", &self.display_name_template)
+            .field("role_claims", &self.inner.role_claims)
+            .field("display_name_template", &self.inner.display_name_template)
             .finish()
     }
 }
@@ -807,10 +829,8 @@ impl std::str::FromStr for DisplayNameTemplate {
     }
 }
 
-/// Name under which a failed [`JWKSWebAuthenticator::set_scope`] requirement is reported.
-pub const SCOPE_RULE_NAME: &str = "scope";
-
-/// The `set_scope` requirement: a rule on `scope`/`scp`, or unsatisfiable for an empty scope.
+/// The `set_scope` requirement: a rule on `scope`/`scp`, or unsatisfiable when the scope is
+/// empty or contains whitespace (a whitespace-split value can never equal it).
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ScopeRequirement {
     Rule(ClaimRule),
@@ -920,10 +940,10 @@ mod test {
         )
     }
 
-    fn org_failed() -> Option<RejectionReason> {
-        Some(RejectionReason::ClaimRuleFailed {
+    fn org_failed() -> RejectionReason {
+        RejectionReason::ClaimRuleFailed {
             rule: "org".to_string(),
-        })
+        }
     }
 
     #[test]
@@ -945,7 +965,7 @@ mod test {
             serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "organizations": ["tenant-b"] }),
         );
         let err = verify(&jwk, &token, &header, &[org_rule("tenant-a")]).unwrap_err();
-        assert_eq!(err.rejection(), org_failed().as_ref());
+        assert_eq!(err.rejection(), Some(&org_failed()));
         let rendered = format!("{err} {err:?}");
         assert!(!rendered.contains("tenant-a"), "{rendered}");
         assert!(!rendered.contains("organizations"), "{rendered}");
@@ -960,15 +980,16 @@ mod test {
             serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u" }),
         );
         let err = verify(&jwk, &token, &header, &[org_rule("tenant-a")]).unwrap_err();
-        assert_eq!(err.rejection(), org_failed().as_ref());
+        assert_eq!(err.rejection(), Some(&org_failed()));
     }
 
     #[test]
     fn test_authenticate_jwt_reports_first_failing_rule_in_order() {
         let (enc, jwk) = ed25519_fixture();
+        // Both rules fail; the first configured one is reported.
         let (token, header) = sign(
             &enc,
-            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "organizations": ["tenant-a"] }),
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "organizations": ["tenant-b"] }),
         );
         let scope = (
             "scopes".to_string(),
@@ -979,7 +1000,15 @@ mod test {
             )
             .unwrap(),
         );
-        let err = verify(&jwk, &token, &header, &[org_rule("tenant-a"), scope]).unwrap_err();
+        let err = verify(
+            &jwk,
+            &token,
+            &header,
+            &[org_rule("tenant-a"), scope.clone()],
+        )
+        .unwrap_err();
+        assert_eq!(err.rejection(), Some(&org_failed()));
+        let err = verify(&jwk, &token, &header, &[scope, org_rule("tenant-a")]).unwrap_err();
         assert_eq!(
             err.rejection(),
             Some(&RejectionReason::ClaimRuleFailed {
@@ -994,25 +1023,6 @@ mod test {
         let (token, header) = sign(&enc, serde_json::json!({ "iss": ISS, "sub": "u" }));
         let err = verify(&jwk, &token, &header, &[]).unwrap_err();
         assert_eq!(err.rejection(), Some(&RejectionReason::AudienceMismatch));
-    }
-
-    #[test]
-    fn test_authenticate_jwt_rejects_token_with_malformed_aud() {
-        let (enc, jwk) = ed25519_fixture();
-        let (token, header) = sign(
-            &enc,
-            serde_json::json!({ "iss": ISS, "aud": 42, "sub": "u" }),
-        );
-        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
-        assert_eq!(err.rejection(), Some(&RejectionReason::AudienceMismatch));
-    }
-
-    #[test]
-    fn test_authenticate_jwt_rejects_token_without_iss() {
-        let (enc, jwk) = ed25519_fixture();
-        let (token, header) = sign(&enc, serde_json::json!({ "aud": AUD, "sub": "u" }));
-        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
-        assert_eq!(err.rejection(), Some(&RejectionReason::IssuerMismatch));
     }
 
     #[test]
@@ -1058,8 +1068,32 @@ mod test {
             serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u" }),
         );
         let err = verify(&other_jwk, &token, &header, &[]).unwrap_err();
-        assert!(matches!(err, Error::JWTDecodeError { .. }), "{err:?}");
+        assert_eq!(
+            err.to_string(),
+            "Failed to decode JWT Token. Failed to decode JWT token. InvalidSignature"
+        );
         assert_eq!(err.rejection(), None);
+    }
+
+    #[test]
+    fn test_authenticate_jwt_uses_token_alg_when_jwk_has_none() {
+        use base64::Engine as _;
+        let key_pair = aws_lc_rs::signature::Ed25519KeyPair::generate().unwrap();
+        let pkcs8 = key_pair.to_pkcs8().unwrap();
+        let enc = jsonwebtoken::EncodingKey::from_ed_der(pkcs8.as_ref());
+        let x = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(aws_lc_rs::signature::KeyPair::public_key(&key_pair).as_ref());
+        let jwk: JsonWebKey = serde_json::from_value(serde_json::json!({
+            "kty": "OKP", "crv": "Ed25519", "kid": "k1", "x": x
+        }))
+        .unwrap();
+        assert_eq!(jwk.alg(), None);
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u" }),
+        );
+        let data = verify(&jwk, &token, &header, &[]).unwrap();
+        assert_eq!(data.claims["sub"], "u");
     }
 
     #[test]
@@ -1074,7 +1108,11 @@ mod test {
         )
         .unwrap();
         let err = verify(&jwk, &token, &header, &[]).unwrap_err();
-        assert!(matches!(err, Error::JWTDecodeError { .. }), "{err:?}");
+        assert_eq!(
+            err.to_string(),
+            "Failed to decode JWT Token. Failed to decode JWT token. ExpiredSignature"
+        );
+        assert_eq!(err.rejection(), None);
     }
 
     // ---- scope sugar ----
@@ -1098,6 +1136,10 @@ mod test {
             ScopeRequirement::new(String::new()),
             ScopeRequirement::Unsatisfiable
         );
+        assert_eq!(
+            ScopeRequirement::new("read write".to_string()),
+            ScopeRequirement::Unsatisfiable
+        );
     }
 
     #[test]
@@ -1118,12 +1160,6 @@ mod test {
         assert!(scope.matches(&serde_json::json!({ "scp": "openid profile" })));
     }
 
-    fn scope_failed() -> Option<RejectionReason> {
-        Some(RejectionReason::ClaimRuleFailed {
-            rule: SCOPE_RULE_NAME.to_string(),
-        })
-    }
-
     #[test]
     fn test_empty_scope_rejects_every_token() {
         let (enc, jwk) = ed25519_fixture();
@@ -1133,7 +1169,7 @@ mod test {
         );
         let scope = ScopeRequirement::new(String::new());
         let err = verify_with_scope(&jwk, &token, &header, Some(&scope), &[]).unwrap_err();
-        assert_eq!(err.rejection(), scope_failed().as_ref());
+        assert_eq!(err.rejection(), Some(&RejectionReason::ScopeMissing));
     }
 
     #[test]
@@ -1146,21 +1182,113 @@ mod test {
         let scope = ScopeRequirement::new("admin".to_string());
         let err =
             verify_with_scope(&jwk, &token, &header, Some(&scope), &[org_rule("x")]).unwrap_err();
-        assert_eq!(err.rejection(), scope_failed().as_ref());
+        assert_eq!(err.rejection(), Some(&RejectionReason::ScopeMissing));
     }
 
     #[test]
-    fn test_caller_rule_named_scope_is_kept_alongside_set_scope() {
-        // A caller rule may use any name, including the scope requirement's report name.
+    fn test_scope_and_caller_rule_failures_are_distinguishable() {
         let (enc, jwk) = ed25519_fixture();
+        let scope = ScopeRequirement::new("admin".to_string());
+        let caller = ("scope".to_string(), org_rule("tenant-a").1);
+        // Scope satisfied, caller rule fails.
         let (token, header) = sign(
             &enc,
             serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "scope": "admin" }),
         );
-        let scope = ScopeRequirement::new("admin".to_string());
-        let caller = (SCOPE_RULE_NAME.to_string(), org_rule("tenant-a").1);
+        let err = verify_with_scope(
+            &jwk,
+            &token,
+            &header,
+            Some(&scope),
+            std::slice::from_ref(&caller),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.rejection(),
+            Some(&RejectionReason::ClaimRuleFailed {
+                rule: "scope".to_string(),
+            })
+        );
+        // Scope fails, caller rule satisfied.
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "organizations": ["tenant-a"] }),
+        );
         let err = verify_with_scope(&jwk, &token, &header, Some(&scope), &[caller]).unwrap_err();
-        assert_eq!(err.rejection(), scope_failed().as_ref());
+        assert_eq!(err.rejection(), Some(&RejectionReason::ScopeMissing));
+    }
+
+    // ---- through `Authenticator::authenticate` (introspection + JWKS fetch) ----
+
+    async fn spawn_idp(jwks: serde_json::Value) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::{Json, Router, routing::get};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let issuer = format!("http://{}/", listener.local_addr().unwrap());
+        let config = serde_json::json!({ "issuer": issuer, "jwks_uri": format!("{issuer}jwks") });
+        let app = Router::new()
+            .route(
+                "/.well-known/openid-configuration",
+                get(move || async move { Json(config) }),
+            )
+            .route("/jwks", get(move || async move { Json(jwks) }));
+        let handle = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (issuer, handle)
+    }
+
+    fn jwks_for(jwk: &JsonWebKey) -> serde_json::Value {
+        let JsonWebKey::Okp(okp) = jwk else {
+            unreachable!("fixture is OKP")
+        };
+        serde_json::json!({ "keys": [
+            { "kty": "OKP", "crv": "Ed25519", "alg": "EdDSA", "kid": "k1", "x": okp.x() }
+        ]})
+    }
+
+    /// Without a chain there is no `can_handle_token` routing: a token that omits `aud`
+    /// used to pass audience validation and now is rejected.
+    #[tokio::test]
+    async fn test_authenticate_rejects_token_without_aud_when_audience_configured() {
+        let (enc, jwk) = ed25519_fixture();
+        let (issuer, server) = spawn_idp(jwks_for(&jwk)).await;
+        let authenticator = JWKSWebAuthenticator::new(&issuer, None)
+            .await
+            .unwrap()
+            .set_accepted_audiences(vec![AUD.to_string()]);
+
+        let (token, _) = sign(&enc, serde_json::json!({ "iss": issuer, "sub": "u" }));
+        let err = authenticator
+            .authenticate(&token, &crate::introspect::introspect(&token))
+            .await
+            .unwrap_err();
+        assert_eq!(err.rejection(), Some(&RejectionReason::AudienceMismatch));
+
+        let (token, _) = sign(
+            &enc,
+            serde_json::json!({ "iss": issuer, "aud": AUD, "sub": "u" }),
+        );
+        let auth = authenticator
+            .authenticate(&token, &crate::introspect::introspect(&token))
+            .await
+            .unwrap();
+        assert_eq!(auth.subject().subject_in_idp(), "u");
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_clone_shares_configuration() {
+        let (_, jwk) = ed25519_fixture();
+        let (issuer, server) = spawn_idp(jwks_for(&jwk)).await;
+        let authenticator = JWKSWebAuthenticator::new(&issuer, None)
+            .await
+            .unwrap()
+            .set_accepted_audiences(vec![AUD.to_string()]);
+        let clone = authenticator.clone();
+        assert!(std::sync::Arc::ptr_eq(&authenticator.inner, &clone.inner));
+        // Configuring a clone does not affect the original.
+        let changed = clone.set_scope("x".to_string());
+        assert!(authenticator.inner.scope.is_none());
+        assert!(changed.inner.scope.is_some());
+        server.abort();
     }
 
     #[test]

--- a/crates/limes/src/kubernetes.rs
+++ b/crates/limes/src/kubernetes.rs
@@ -147,10 +147,9 @@ impl Authenticator for KubernetesAuthenticator {
                 }
                 IntrospectionResult::JWTBearer { iss, .. } => {
                     if !self.issuers.iter().any(|i| iss.contains(i)) {
-                        return Err(Error::IssuerMismatch {
-                            expected: self.issuers.clone(),
-                            actual: iss.iter().cloned().collect(),
-                        });
+                        return Err(Error::rejected(
+                            crate::error::RejectionReason::IssuerMismatch,
+                        ));
                     }
                 }
             }
@@ -288,10 +287,9 @@ fn validate_audience(expected: &[String], received: &[String]) -> Result<()> {
     }
 
     if !expected.iter().any(|expected| received.contains(expected)) {
-        return Err(Error::AudienceMismatch {
-            expected: expected.to_vec(),
-            actual: received.to_vec(),
-        });
+        return Err(Error::rejected(
+            crate::error::RejectionReason::AudienceMismatch,
+        ));
     }
 
     Ok(())

--- a/crates/limes/src/kubernetes.rs
+++ b/crates/limes/src/kubernetes.rs
@@ -146,9 +146,10 @@ impl Authenticator for KubernetesAuthenticator {
                     ));
                 }
                 IntrospectionResult::JWTBearer { iss, .. } => {
+                    // The token is not verified yet, so this is not a `TokenRejected`.
                     if !self.issuers.iter().any(|i| iss.contains(i)) {
-                        return Err(Error::rejected(
-                            crate::error::RejectionReason::IssuerMismatch,
+                        return Err(Error::unauthenticated(
+                            "Token issuer is not accepted by the Kubernetes Authenticator",
                         ));
                     }
                 }

--- a/crates/limes/src/lib.rs
+++ b/crates/limes/src/lib.rs
@@ -146,6 +146,7 @@
 
 mod authenticator;
 mod chain;
+pub mod claims;
 pub mod error;
 pub mod introspect;
 #[cfg(feature = "jwks")]
@@ -157,6 +158,8 @@ pub mod kubernetes;
 
 pub use authenticator::{Authentication, Authenticator, PrincipalType};
 pub use chain::{AuthenticatorChain, AuthenticatorChainBuilder, AuthenticatorEnum};
+pub use claims::{ClaimOperator, ClaimRule, ClaimRuleError, Separator};
+pub use error::RejectionReason;
 pub use subject::Subject;
 
 pub use subject::{format_subject, parse_subject};

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ check-format:
 	cargo fmt --all -- --check
 
 check-clippy:
-	cargo clippy --all-features --workspace -- -D warnings
+	cargo clippy --all-features --all-targets --workspace -- -D warnings
 	cargo clippy --workspace -- -D warnings
 	cargo clippy --workspace --no-default-features -- -D warnings
 	cargo clippy --workspace --features "all" -- -D warnings


### PR DESCRIPTION
`ClaimRule` states a requirement on one claim — `any_of`, `all_of`, `none_of`
or `exists` over a claim name or dotted path, with an optional whitespace or
literal separator for delimited strings. Rules are validated when built:
`ClaimRule::{any_of, all_of, none_of, exists}` and `with_separator` reject an
empty path or value list, an empty separator, and a value the separator would
split. `JWKSWebAuthenticator::with_required_claims` evaluates them in order
after the signature, issuer, audience and scope checks; every rule must hold,
and missing, `null` and non-scalar claims fail closed. Matching borrows from
the decoded claims without allocating, and the authenticator's configuration
sits behind an `Arc` so a per-request clone is a refcount bump.

`set_scope` takes one whitespace-free scope, read from the `scope` claim or
`scp` if `scope` is absent, as a whitespace-delimited string or an array of
strings; `Authentication::scopes()` reads the claim the same way.

Tokens are rejected when `nbf` lies in the future, and when audiences are
configured and the `aud` claim is absent. A key id absent from the JWKS is an
authentication failure of that token, and the key id stays out of the error.

`Error::TokenRejected { rejection: RejectionReason }` marks a token whose
signature verified and whose claims did not: audience, issuer, scope, a named
required-claim rule, or the subject claim. It carries names only, never claim
values, so it is safe to log and audit; unverifiable tokens keep their existing
errors. The Kubernetes authenticator reports its pre-verification issuer check
as `Unauthenticated` and its post-review audience check as `TokenRejected`.

BREAKING CHANGE: `Error` is `#[non_exhaustive]`; `Error::AudienceMismatch` and
`Error::IssuerMismatch` are removed — audience and issuer failures are
`Error::TokenRejected`, and the Kubernetes issuer pre-check is
`Error::Unauthenticated`. A missing subject claim is `TokenRejected`.
`set_scope` returns `Result` and rejects a scope that is empty or contains
whitespace. With audiences configured, a token without an `aud` claim is
rejected, as is a token whose `nbf` lies in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable JWT claim rules for nested claims, fallback claims, existence checks, set matching, scalar conversion, and value splitting.
  * Added public APIs for defining and evaluating claim requirements.
  * Scope claims now support strings and arrays, including whitespace-separated values and fallback handling.
  * JWT validation now checks the `nbf` claim when present.

* **Bug Fixes**
  * Improved handling of malformed or unsupported claim values.
  * Added clearer rejection reasons for invalid scopes and authentication failures.
  * Improved Kubernetes authentication responses for issuer and audience mismatches.
  * Scope configuration now rejects empty or whitespace-containing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->