### PR TITLE
fix(claims)!: close separator and exists fail-open paths

### DIFF
--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -185,10 +185,11 @@ impl Authentication {
 
     /// Get the scopes of the token from the `scope` claim, or `scp` if `scope` is absent.
     ///
-    /// Values are read exactly as scope enforcement reads them: a whitespace-delimited
-    /// string, or an array of strings stating one scope per element. Anything else (an
-    /// object, a number, or an array holding non-strings) is malformed and yields nothing.
-    /// Returns an empty iterator if neither claim is present.
+    /// Values are read exactly as scope enforcement reads them: a lone string is split on
+    /// whitespace, while an array states one scope per element, so its strings are returned
+    /// whole and never split. Anything else (an object, a number, or an array holding
+    /// non-strings) is malformed and yields nothing. Returns an empty iterator if neither
+    /// claim is present.
     pub fn scopes(&self) -> impl Iterator<Item = &str> {
         let (items, split) = scope_claim(&self.claims)
             .and_then(crate::claims::strings)

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -15,12 +15,12 @@ pub(crate) const SCOPE_CLAIM: &str = "scope";
 /// Array-shaped alternative to `scope` emitted by some IdPs; consulted when `scope` is absent.
 pub(crate) const SCP_CLAIM: &str = "scp";
 
-/// The `scope` claim, or `scp` if `scope` is absent or `null`.
+/// The `scope` claim, or `scp` if `scope` carries no scopes.
+///
+/// Resolved through [`crate::claims::resolve`], the one owner of that choice, so the scope
+/// requirement and [`Authentication::scopes`] always read the same claim.
 pub(crate) fn scope_claim(claims: &serde_json::Value) -> Option<&serde_json::Value> {
-    [SCOPE_CLAIM, SCP_CLAIM]
-        .into_iter()
-        .filter_map(|c| claims.get(c))
-        .find(|v| !v.is_null())
+    crate::claims::resolve(claims, [SCOPE_CLAIM, SCP_CLAIM])
 }
 
 pub trait Authenticator
@@ -194,6 +194,8 @@ impl Authentication {
         let (items, split) = scope_claim(&self.claims)
             .and_then(crate::claims::strings)
             .unwrap_or((&[], false));
+        // `strings` rejects non-strings, so a malformed claim yields nothing — the same
+        // reading the scope requirement enforces.
         crate::claims::ClaimValues::new(items, Some(&crate::claims::Separator::Whitespace), split)
             .filter_map(|v| match v {
                 std::borrow::Cow::Borrowed(s) => Some(s),

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -190,10 +190,10 @@ impl Authentication {
     /// or an array holding non-strings) is malformed and yields nothing. Returns an empty
     /// iterator if neither claim is present.
     pub fn scopes(&self) -> impl Iterator<Item = &str> {
-        let items = scope_claim(&self.claims)
+        let (items, split) = scope_claim(&self.claims)
             .and_then(crate::claims::strings)
-            .unwrap_or_default();
-        crate::claims::ClaimValues::new(items, Some(&crate::claims::Separator::Whitespace))
+            .unwrap_or((&[], false));
+        crate::claims::ClaimValues::new(items, Some(&crate::claims::Separator::Whitespace), split)
             .filter_map(|v| match v {
                 std::borrow::Cow::Borrowed(s) => Some(s),
                 std::borrow::Cow::Owned(_) => None,
@@ -279,12 +279,13 @@ mod test {
         assert_eq!(auth.scopes().collect::<Vec<_>>(), ["a"]);
     }
 
+    /// The array form of `scope` states one scope per element, so elements are not split.
     #[test]
-    fn test_scopes_splits_array_elements_like_enforcement() {
+    fn test_scopes_does_not_split_array_elements() {
         let auth = auth_with_claims(serde_json::json!({ "scope": ["openid profile", "email"] }));
         assert_eq!(
             auth.scopes().collect::<Vec<_>>(),
-            ["openid", "profile", "email"]
+            ["openid profile", "email"]
         );
     }
 

--- a/crates/limes/src/authenticator.rs
+++ b/crates/limes/src/authenticator.rs
@@ -185,10 +185,10 @@ impl Authentication {
 
     /// Get the scopes of the token from the `scope` claim, or `scp` if `scope` is absent.
     ///
-    /// Values are read exactly as scope enforcement reads them: a whitespace-delimited string
-    /// or an array of strings, each split on whitespace. Anything else (an object, a number,
-    /// or an array holding non-strings) is malformed and yields nothing. Returns an empty
-    /// iterator if neither claim is present.
+    /// Values are read exactly as scope enforcement reads them: a whitespace-delimited
+    /// string, or an array of strings stating one scope per element. Anything else (an
+    /// object, a number, or an array holding non-strings) is malformed and yields nothing.
+    /// Returns an empty iterator if neither claim is present.
     pub fn scopes(&self) -> impl Iterator<Item = &str> {
         let (items, split) = scope_claim(&self.claims)
             .and_then(crate::claims::strings)

--- a/crates/limes/src/claims.rs
+++ b/crates/limes/src/claims.rs
@@ -115,8 +115,8 @@ impl ClaimRule {
     }
 
     /// `claim` must be populated (`true`) — present, not `null`, and carrying a non-empty
-    /// value — or absent or `null` (`false`). A claim that is present but empty satisfies
-    /// neither.
+    /// value or, for an object or an array of objects, at least one member — or absent or
+    /// `null` (`false`). A claim that is present but empty satisfies neither.
     ///
     /// # Errors
     /// See [`ClaimRuleError`].
@@ -215,10 +215,11 @@ impl ClaimRule {
     /// array of scalars is its elements, and strings are split by the separator. Objects and
     /// arrays holding non-scalars are *malformed*: they exist but carry no value.
     ///
-    /// `exists: true` holds when the claim carries at least one non-empty value, so a claim
-    /// that is present but empty — `[]`, `""`, `{}` — satisfies it no more than a missing
-    /// one. `exists: false` keeps its narrow meaning of absent or `null`, so the two are not
-    /// complements: an empty claim fails both.
+    /// `exists: true` holds when the claim is *populated*: it carries at least one non-empty
+    /// value, or — being malformed and so carrying none — holds at least one member or
+    /// element. A claim that is present but empty (`[]`, `""`, `{}`) satisfies it no more
+    /// than a missing one. `exists: false` keeps its narrow meaning of absent or `null`, so
+    /// the two are not complements: an empty claim fails both.
     #[must_use]
     pub fn matches(&self, claims: &serde_json::Value) -> bool {
         let value = self

--- a/crates/limes/src/claims.rs
+++ b/crates/limes/src/claims.rs
@@ -60,7 +60,7 @@ pub enum ClaimRuleError {
     InvalidClaimPath,
     #[error("{operator} must not be empty")]
     EmptyValueList { operator: &'static str },
-    #[error("{operator} must not contain empty strings")]
+    #[error("{operator} must not contain blank values")]
     EmptyValue { operator: &'static str },
     #[error("separator must not be empty")]
     EmptySeparator,
@@ -82,6 +82,47 @@ pub struct ClaimRule {
     claims: Vec<String>,
     separator: Option<Separator>,
     operator: ClaimOperator,
+    /// Derived from `operator`; present only for a deny.
+    deny: Option<DenyIndex>,
+}
+
+/// Where a banned value can start, and how long it can be there.
+///
+/// A scan position tests only the values that could begin with the byte at it, so the cost of
+/// a deny follows the length of the claim rather than the size of the deny set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DenyIndex {
+    lengths_by_first_byte: std::collections::HashMap<u8, Vec<usize>>,
+}
+
+impl DenyIndex {
+    fn new(set: &HashSet<String>) -> Self {
+        let mut lengths_by_first_byte: std::collections::HashMap<u8, Vec<usize>> =
+            std::collections::HashMap::new();
+        for value in set {
+            if let Some(&first) = value.as_bytes().first() {
+                lengths_by_first_byte
+                    .entry(first)
+                    .or_default()
+                    .push(value.len());
+            }
+        }
+        for lengths in lengths_by_first_byte.values_mut() {
+            lengths.sort_unstable();
+            lengths.dedup();
+        }
+        Self {
+            lengths_by_first_byte,
+        }
+    }
+
+    /// The lengths a banned value can have starting at `start`, empty when none can.
+    fn lengths_at(&self, item: &str, start: usize) -> &[usize] {
+        item.as_bytes()
+            .get(start)
+            .and_then(|byte| self.lengths_by_first_byte.get(byte))
+            .map_or(&[], Vec::as_slice)
+    }
 }
 
 impl ClaimRule {
@@ -171,7 +212,9 @@ impl ClaimRule {
             if values.is_empty() {
                 return Err(ClaimRuleError::EmptyValueList { operator: name });
             }
-            if values.iter().any(String::is_empty) {
+            // A blank claim carries nothing, so selection skips it. A rule that could name
+            // a blank value would have one to find there, and skipping would lose it.
+            if values.iter().any(|v| v.trim().is_empty()) {
                 return Err(ClaimRuleError::EmptyValue { operator: name });
             }
             let split_by_separator = |v: &str| match &separator {
@@ -188,10 +231,15 @@ impl ClaimRule {
                 });
             }
         }
+        let deny = match &operator {
+            ClaimOperator::NoneOf(set) => Some(DenyIndex::new(set)),
+            _ => None,
+        };
         Ok(Self {
             claims,
             separator,
             operator,
+            deny,
         })
     }
 
@@ -259,10 +307,10 @@ impl ClaimRule {
             // the claim can yield a banned value — array elements included, which a grant
             // never splits.
             ClaimOperator::NoneOf(set) => items.is_some_and(|(items, _)| {
-                let lengths = needle_lengths(set);
+                let deny = self.deny.as_ref();
                 !items
                     .iter()
-                    .any(|item| is_banned(&scalar_text(item), set, &lengths, separator))
+                    .any(|item| is_banned(&scalar_text(item), set, deny, separator))
             }),
             // Splitting is the expensive part, so a multi-value `all_of` over a split string
             // splits once instead of once per needle.
@@ -325,14 +373,6 @@ fn is_populated(value: &serde_json::Value) -> bool {
     }
 }
 
-/// The distinct byte lengths a banned value can have, shortest first.
-fn needle_lengths(set: &HashSet<String>) -> Vec<usize> {
-    let mut lengths: Vec<usize> = set.iter().map(String::len).collect();
-    lengths.sort_unstable();
-    lengths.dedup();
-    lengths
-}
-
 /// The comparable text of a scalar item.
 fn scalar_text(value: &serde_json::Value) -> Cow<'_, str> {
     match value {
@@ -350,12 +390,12 @@ fn scalar_text(value: &serde_json::Value) -> Cow<'_, str> {
 /// never produces `admin`, hiding a banned group from the deny. Scanning from every position
 /// a value could start at sees all readings, so no join can smuggle a banned value through.
 ///
-/// `lengths` are the distinct lengths of the deny set, so each position costs one lookup per
-/// length rather than one comparison per banned value.
+/// `index` narrows each position to the values that could begin there, so the scan costs a
+/// lookup per candidate length rather than a comparison per banned value.
 fn is_banned(
     item: &str,
     set: &HashSet<String>,
-    lengths: &[usize],
+    index: Option<&DenyIndex>,
     separator: Option<&Separator>,
 ) -> bool {
     if set.contains(item) {
@@ -366,8 +406,11 @@ fn is_banned(
     let Some(separator) = separator.filter(|s| contains_separator(item, s)) else {
         return false;
     };
+    let Some(index) = index else {
+        return false;
+    };
     let banned_at = |start: usize| {
-        lengths.iter().any(|&len| {
+        index.lengths_at(item, start).iter().any(|&len| {
             item.get(start..start + len).is_some_and(|value| {
                 set.contains(value) && ends_delimited(item, start + len, separator)
             })
@@ -1229,6 +1272,25 @@ mod tests {
         let claims = json!({ "a": "other", "b": ["admin"] });
         assert!(!any.matches(&claims));
         assert!(!all.matches(&claims));
+    }
+
+    /// Selection skips a blank path, so no rule may name a value that could only be found
+    /// there — otherwise a deny walks past the claim carrying its banned value.
+    #[test]
+    fn a_rule_cannot_name_a_blank_value() {
+        for blank in ["", " ", "\t", "\u{00a0}", "  \n "] {
+            for operator in [any_of(&[blank]), all_of(&[blank]), none_of(&[blank])] {
+                assert!(
+                    matches!(
+                        ClaimRule::new("c", None, operator).unwrap_err(),
+                        ClaimRuleError::EmptyValue { .. }
+                    ),
+                    "{blank:?} must not be nameable"
+                );
+            }
+        }
+        // A value merely containing whitespace is fine.
+        assert!(ClaimRule::none_of("c", ["Domain Admins"]).is_ok());
     }
 
     /// Which claim is read must not depend on how a rule is formatted.

--- a/crates/limes/src/claims.rs
+++ b/crates/limes/src/claims.rs
@@ -6,7 +6,9 @@
 
 use std::{borrow::Cow, collections::HashSet};
 
-/// How a string claim is split into values before set operators are applied.
+/// How a lone string claim is split into values before set operators are applied. Array
+/// elements are not split by `any_of`/`all_of`/`exists`; `none_of` additionally considers the
+/// split reading so that a deny cannot be evaded by embedding a banned value in an element.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Separator {
@@ -30,8 +32,17 @@ pub enum ClaimOperator {
     /// `none_of ["admin"]` does NOT fire on `"scope": "openid admin"` — that claim's single
     /// value is `"openid admin"`. Configure the separator that matches the claim's format
     /// when denying values inside delimited strings.
+    ///
+    /// With a separator, a deny fires if *any* reading of the claim yields a banned value:
+    /// the values as written and the pieces they split into, array elements included. A grant
+    /// never splits array elements, so the two directions are deliberately asymmetric — each
+    /// errs towards refusing access.
     NoneOf(HashSet<String>),
-    /// `true`: the claim is present and not `null`; `false`: absent or `null`.
+    /// `true`: the claim is populated — present, not `null`, and carrying at least one
+    /// non-empty value or, for an object, at least one member. `false`: absent or `null`.
+    ///
+    /// These are not opposites: a claim that is present but empty (`[]`, `""`, `{}`)
+    /// satisfies neither.
     Exists(bool),
 }
 
@@ -39,10 +50,7 @@ pub enum ClaimOperator {
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
 pub enum ClaimRuleError {
-    #[error(
-        "claim path must not be empty, contain empty segments, or contain `/` or `:` \
-         (a claim whose name contains a dot, such as a URI, is not addressable)"
-    )]
+    #[error("claim path must not be empty or contain empty segments")]
     InvalidClaimPath,
     #[error("{operator} must not be empty")]
     EmptyValueList { operator: &'static str },
@@ -70,9 +78,10 @@ pub struct ClaimRule {
 impl ClaimRule {
     /// At least one of `values` must be a value of `claim`.
     ///
-    /// `claim` is a claim name or a dotted path such as `realm_access.roles`. Every dot
-    /// nests: a claim whose name itself contains a dot (e.g. the URI-shaped
-    /// `https://example.com/roles`) is not addressable. The same applies to all constructors.
+    /// `claim` is a dotted path such as `realm_access.roles`, which nests on every dot, or —
+    /// when it contains `/` or `:` — the whole name of one claim, as identity providers use
+    /// for namespaced custom claims (`https://example.com/roles`). The same applies to all
+    /// constructors.
     ///
     /// # Errors
     /// See [`ClaimRuleError`].
@@ -105,7 +114,9 @@ impl ClaimRule {
         Self::new(claim, None, ClaimOperator::NoneOf(collect(values)))
     }
 
-    /// `claim` must be present and not `null` (`true`), or absent or `null` (`false`).
+    /// `claim` must be populated (`true`) — present, not `null`, and carrying a non-empty
+    /// value — or absent or `null` (`false`). A claim that is present but empty satisfies
+    /// neither.
     ///
     /// # Errors
     /// See [`ClaimRuleError`].
@@ -113,7 +124,9 @@ impl ClaimRule {
         Self::new(claim, None, ClaimOperator::Exists(expected))
     }
 
-    /// Split string claim values on `separator` before matching.
+    /// Split a lone string claim on `separator` before matching. Array elements are not
+    /// split by a grant, since an array already states one value per element; `none_of` also
+    /// denies on the split reading so a deny cannot be evaded.
     ///
     /// # Errors
     /// [`ClaimRuleError::EmptySeparator`], or [`ClaimRuleError::ValueContainsSeparator`] if a
@@ -176,7 +189,8 @@ impl ClaimRule {
     /// appears only in a fallback path is not seen when the primary path is present.
     ///
     /// # Errors
-    /// [`ClaimRuleError::InvalidClaimPath`] if the path is empty or has empty segments.
+    /// [`ClaimRuleError::InvalidClaimPath`] if the path is empty, or nests on a dot with an
+    /// empty segment.
     pub fn or_claim(mut self, claim: impl Into<String>) -> Result<Self, ClaimRuleError> {
         self.claims.push(validate_path(claim.into())?);
         Ok(self)
@@ -216,12 +230,25 @@ impl ClaimRule {
         let separator = self.separator.as_ref();
         let values = || items.map(|(items, split)| ClaimValues::new(items, separator, split));
         match &self.operator {
-            ClaimOperator::Exists(true) => values().is_some_and(|mut v| v.any(|x| !x.is_empty())),
+            ClaimOperator::Exists(true) => match value {
+                None => false,
+                // An object or an array of objects carries no comparable value, but it is
+                // still content: `exists` asks whether the claim is populated.
+                Some(serde_json::Value::Object(map)) => !map.is_empty(),
+                Some(serde_json::Value::Array(arr)) if items.is_none() => !arr.is_empty(),
+                Some(_) => values().is_some_and(|mut v| v.any(|x| !x.is_empty())),
+            },
             ClaimOperator::Exists(false) => value.is_none(),
             ClaimOperator::AnyOf(set) => values().is_some_and(|mut v| v.any(|x| set.contains(&*x))),
-            ClaimOperator::NoneOf(set) => {
-                values().is_some_and(|mut v| !v.any(|x| set.contains(&*x)))
-            }
+            // A deny holds only if no reading of the claim yields a banned value: both the
+            // values as the issuer wrote them and, when a separator is configured, the pieces
+            // it splits into — including inside array elements, which a grant never splits.
+            ClaimOperator::NoneOf(set) => items.is_some_and(|(items, _)| {
+                let banned = |separator, split| {
+                    ClaimValues::new(items, separator, split).any(|x| set.contains(&*x))
+                };
+                !(banned(None, false) || (separator.is_some() && banned(separator, true)))
+            }),
             // Splitting is the expensive part, so a multi-value `all_of` over a split string
             // splits once instead of once per needle.
             ClaimOperator::AllOf(set) if separator.is_some() && set.len() > 1 => values()
@@ -272,13 +299,19 @@ fn collect<I: IntoIterator<Item = S>, S: Into<String>>(values: I) -> HashSet<Str
 }
 
 fn validate_path(path: String) -> Result<String, ClaimRuleError> {
-    // `/` and `:` only appear in URI-shaped claim *names*, which dotted paths cannot address.
-    // Such a path resolves to nothing, which `exists: false` would read as "holds for every
-    // token" — so reject it rather than let a rule silently admit everyone.
-    if path.is_empty() || path.split('.').any(str::is_empty) || path.contains(['/', ':']) {
+    if path.is_empty() || (!is_claim_name(&path) && path.split('.').any(str::is_empty)) {
         return Err(ClaimRuleError::InvalidClaimPath);
     }
     Ok(path)
+}
+
+/// Whether a path names one claim outright rather than describing a nesting.
+///
+/// Identity providers namespace custom claims as URIs (`https://example.com/roles`,
+/// `kubernetes.io/serviceaccount/namespace`). A nesting never contains `/` or `:`, so those
+/// characters distinguish the two without ambiguity.
+fn is_claim_name(path: &str) -> bool {
+    path.contains(['/', ':'])
 }
 
 /// Streams the comparable values of scalar items without collecting: strings are borrowed
@@ -343,16 +376,21 @@ impl<'a> Iterator for ClaimValues<'a> {
     }
 }
 
-/// Navigate nested claims using dot-notation (e.g. `resource_access.account.roles`).
-/// Every dot nests — a claim whose *name* contains a dot (e.g. the URI-shaped
-/// `https://example.com/roles`) is not addressable, so a flat key can never shadow the
-/// nested claim a rule targets. Returns `None` if the path is absent.
+/// Resolve a claim path.
+///
+/// A path containing `/` or `:` names a single claim and is looked up whole — that is how
+/// identity providers namespace custom claims (`https://example.com/roles`). Any other path
+/// nests on every dot, so a flat claim spelled like a nesting can never shadow the nested
+/// claim a rule targets. Returns `None` if the path is absent.
 pub(crate) fn navigate<'a>(
     claims: &'a serde_json::Value,
-    dot_path: &str,
+    path: &str,
 ) -> Option<&'a serde_json::Value> {
+    if is_claim_name(path) {
+        return claims.get(path);
+    }
     let mut current = claims;
-    for part in dot_path.split('.') {
+    for part in path.split('.') {
         current = current.get(part)?;
     }
     Some(current)
@@ -447,26 +485,41 @@ mod tests {
         );
     }
 
-    /// An unresolvable path makes `exists: false` hold for every token, so paths that can
-    /// only ever be claim *names* — not addressable as dotted paths — are rejected up front.
+    /// Identity providers namespace custom claims as URIs. Such a name is looked up whole,
+    /// so the rule works and `exists: false` cannot be satisfied by a path that could never
+    /// resolve.
     #[test]
-    fn new_rejects_uri_shaped_claim_paths() {
-        for path in [
-            "https://example.com/roles",
-            "kubernetes.io/serviceaccount/namespace",
-            "http://schemas.microsoft.com/identity/claims/objectidentifier",
-        ] {
-            assert_eq!(
-                ClaimRule::new(path, None, any_of(&["a"])).unwrap_err(),
-                ClaimRuleError::InvalidClaimPath,
-                "path {path:?}"
-            );
-            assert_eq!(
-                ClaimRule::new(path, None, ClaimOperator::Exists(false)).unwrap_err(),
-                ClaimRuleError::InvalidClaimPath,
-                "path {path:?}"
-            );
-        }
+    fn uri_shaped_claim_names_are_looked_up_whole() {
+        let claims = json!({
+            "https://myapp.example.com/org": ["tenant-a"],
+            "kubernetes.io/serviceaccount/namespace": "prod",
+        });
+        assert!(
+            ClaimRule::any_of("https://myapp.example.com/org", ["tenant-a"])
+                .unwrap()
+                .matches(&claims)
+        );
+        assert!(
+            ClaimRule::any_of("kubernetes.io/serviceaccount/namespace", ["prod"])
+                .unwrap()
+                .matches(&claims)
+        );
+        assert!(
+            ClaimRule::exists("https://myapp.example.com/org", true)
+                .unwrap()
+                .matches(&claims)
+        );
+        assert!(
+            !ClaimRule::exists("https://myapp.example.com/org", false)
+                .unwrap()
+                .matches(&claims)
+        );
+        // Empty segments are only meaningful for a nesting, so a URI keeps its `//`.
+        assert!(
+            ClaimRule::exists("https://other.example.com/x", false)
+                .unwrap()
+                .matches(&claims)
+        );
     }
 
     #[test]
@@ -644,20 +697,38 @@ mod tests {
         }
     }
 
-    /// An object carries no comparable value, so it satisfies no operator — including
-    /// `exists`, which would otherwise report a claim no rule can act on as usable.
+    /// An object carries no comparable value, so no set operator can hold. `exists` asks a
+    /// different question — whether the claim is populated — and a populated object is.
     #[test]
-    fn object_claim_fails_every_operator() {
+    fn object_claim_matches_no_set_operator_but_is_populated() {
         let claims = claims_with(&json!({"a": "b"}));
         assert!(!rule("c", any_of(&["a"])).matches(&claims));
         assert!(!rule("c", all_of(&["a"])).matches(&claims));
         assert!(!rule("c", none_of(&["zzz"])).matches(&claims));
-        assert!(!rule("c", ClaimOperator::Exists(true)).matches(&claims));
+        assert!(rule("c", ClaimOperator::Exists(true)).matches(&claims));
         assert!(!rule("c", ClaimOperator::Exists(false)).matches(&claims));
+
+        // A Keycloak-shaped nested claim is reachable both ways.
+        let keycloak = json!({ "realm_access": { "roles": ["admin"] } });
+        assert!(
+            ClaimRule::exists("realm_access", true)
+                .unwrap()
+                .matches(&keycloak)
+        );
+        assert!(
+            ClaimRule::any_of("realm_access.roles", ["admin"])
+                .unwrap()
+                .matches(&keycloak)
+        );
+
+        // An empty object is present but not populated.
+        let empty = claims_with(&json!({}));
+        assert!(!rule("c", ClaimOperator::Exists(true)).matches(&empty));
+        assert!(!rule("c", ClaimOperator::Exists(false)).matches(&empty));
     }
 
     #[test]
-    fn array_with_non_scalar_element_fails_every_operator() {
+    fn array_with_non_scalar_element_matches_no_set_operator() {
         for value in [
             json!(["a", ["b"]]),
             json!(["a", {"k": "v"}]),
@@ -667,7 +738,8 @@ mod tests {
             assert!(!rule("c", any_of(&["a"])).matches(&claims));
             assert!(!rule("c", all_of(&["a"])).matches(&claims));
             assert!(!rule("c", none_of(&["zzz"])).matches(&claims));
-            assert!(!rule("c", ClaimOperator::Exists(true)).matches(&claims));
+            // Not comparable, but populated.
+            assert!(rule("c", ClaimOperator::Exists(true)).matches(&claims));
             assert!(!rule("c", ClaimOperator::Exists(false)).matches(&claims));
         }
     }
@@ -798,8 +870,8 @@ mod tests {
         });
         assert!(!rule("realm_access.roles", none_of(&["banned"])).matches(&attack));
 
-        // A `null` flat key cannot hide the nested claim from `exists`.
-        let null_flat = json!({ "a": { "b": "real" } });
+        // A flat key spelled like the nesting, even a `null` one, cannot hide it.
+        let null_flat = json!({ "a.b": null, "a": { "b": "real" } });
         assert!(rule("a.b", ClaimOperator::Exists(true)).matches(&null_flat));
         assert!(!rule("a.b", ClaimOperator::Exists(false)).matches(&null_flat));
 
@@ -865,6 +937,25 @@ mod tests {
         assert!(!r(&["a", "z"]).matches(&claims));
         assert!(!r(&["a", "b", "c", "d"]).matches(&claims));
         assert!(r(&["a"]).matches(&claims));
+    }
+
+    /// A deny must not be evadable by embedding the banned value in an array element, even
+    /// though a grant deliberately refuses to split those elements.
+    #[test]
+    fn none_of_denies_a_banned_value_inside_an_array_element() {
+        let smuggled = claims_with(&json!(["x,admin"]));
+        let deny = rule_sep("c", Separator::Literal(",".into()), none_of(&["admin"]));
+        assert!(!deny.matches(&smuggled));
+        // The same claim as a lone string is denied too.
+        assert!(!deny.matches(&claims_with(&json!("x,admin"))));
+        // ...while the grant direction still refuses to manufacture the value.
+        let grant = rule_sep("c", Separator::Literal(",".into()), any_of(&["admin"]));
+        assert!(!grant.matches(&smuggled));
+
+        // Values the issuer wrote are denied regardless of the separator.
+        assert!(!deny.matches(&claims_with(&json!(["admin"]))));
+        // An unrelated claim still passes the deny.
+        assert!(deny.matches(&claims_with(&json!(["users"]))));
     }
 
     #[test]

--- a/crates/limes/src/claims.rs
+++ b/crates/limes/src/claims.rs
@@ -6,9 +6,12 @@
 
 use std::{borrow::Cow, collections::HashSet};
 
-/// How a lone string claim is split into values before set operators are applied. Array
-/// elements are not split by `any_of`/`all_of`/`exists`; `none_of` additionally considers the
-/// split reading so that a deny cannot be evaded by embedding a banned value in an element.
+/// How a claim is read as a list of values.
+///
+/// A grant (`any_of`/`all_of`) and `exists` split a lone string into pieces; array elements
+/// are left whole, since an array already states one value per element. A deny (`none_of`)
+/// does not split at all: it looks for a banned value at any position the separator
+/// delimits, in every item, so no way of joining values can hide one from it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Separator {
@@ -28,15 +31,18 @@ pub enum ClaimOperator {
     AllOf(HashSet<String>),
     /// No claim value is in the set. A missing claim fails.
     ///
-    /// A value is the *whole* string unless a separator is configured: without one,
+    /// A value is the *whole* item unless a separator is configured: without one,
     /// `none_of ["admin"]` does NOT fire on `"scope": "openid admin"` — that claim's single
     /// value is `"openid admin"`. Configure the separator that matches the claim's format
     /// when denying values inside delimited strings.
     ///
-    /// With a separator, a deny fires if *any* reading of the claim yields a banned value:
-    /// the values as written and the pieces they split into, array elements included. A grant
-    /// never splits array elements, so the two directions are deliberately asymmetric — each
-    /// errs towards refusing access.
+    /// With a separator a deny fires wherever a banned value sits between delimiters — the
+    /// start of an item or a separator on the left, a separator or the end of the item on the
+    /// right — in every item, array elements included. It never splits, because splitting is
+    /// lossy: an item ending in a proper prefix of a multi-character separator would shift the
+    /// boundaries after it and hide the value that follows. A grant does split, and never
+    /// splits array elements, so the two directions are deliberately asymmetric — each errs
+    /// towards refusing access.
     NoneOf(HashSet<String>),
     /// `true`: the claim is populated — present, not `null`, and carrying at least one
     /// non-empty value or, for an object, at least one member. `false`: absent or `null`.
@@ -58,8 +64,11 @@ pub enum ClaimRuleError {
     EmptyValue { operator: &'static str },
     #[error("separator must not be empty")]
     EmptySeparator,
-    /// A value the separator would split can never equal a split piece, so the rule could
-    /// never match it — and a `none_of` rule would never deny it.
+    /// Grants only. A grant compares split pieces, and no piece can contain the separator,
+    /// so such a value could only ever match an array element — where the separator is
+    /// already inert, since a grant does not split elements. The rule is therefore either
+    /// dead or better written without a separator. A deny reads values by position rather
+    /// than by splitting and matches them correctly, so it accepts them.
     #[error("{operator} value `{value}` contains the separator")]
     ValueContainsSeparator {
         operator: &'static str,
@@ -124,13 +133,13 @@ impl ClaimRule {
         Self::new(claim, None, ClaimOperator::Exists(expected))
     }
 
-    /// Split a lone string claim on `separator` before matching. Array elements are not
-    /// split by a grant, since an array already states one value per element; `none_of` also
-    /// denies on the split reading so a deny cannot be evaded.
+    /// Read the claim as a list delimited by `separator`. A grant splits a lone string,
+    /// leaving array elements whole; a deny matches a banned value at any delimited position
+    /// in any item. See [`Separator`].
     ///
     /// # Errors
     /// [`ClaimRuleError::EmptySeparator`], or [`ClaimRuleError::ValueContainsSeparator`] if a
-    /// listed value contains the separator (it could never match a split piece).
+    /// *grant* lists a value containing the separator, which no split piece can equal.
     pub fn with_separator(self, separator: Separator) -> Result<Self, ClaimRuleError> {
         Self::new_with_claims(self.claims, Some(separator), self.operator)
     }
@@ -157,6 +166,7 @@ impl ClaimRule {
             ClaimOperator::NoneOf(v) => ("none_of", Some(v)),
             ClaimOperator::Exists(_) => ("exists", None),
         };
+        let grant = matches!(operator, ClaimOperator::AnyOf(_) | ClaimOperator::AllOf(_));
         if let Some(values) = values {
             if values.is_empty() {
                 return Err(ClaimRuleError::EmptyValueList { operator: name });
@@ -169,7 +179,9 @@ impl ClaimRule {
                 Some(Separator::Literal(sep)) => v.contains(sep.as_str()),
                 None => false,
             };
-            if let Some(value) = values.iter().find(|v| split_by_separator(v)) {
+            // A deny reads values by position, not by splitting, so it can name a value that
+            // contains the separator. A grant compares split pieces, where such a value is dead.
+            if grant && let Some(value) = values.iter().find(|v| split_by_separator(v)) {
                 return Err(ClaimRuleError::ValueContainsSeparator {
                     operator: name,
                     value: value.clone(),
@@ -183,10 +195,11 @@ impl ClaimRule {
         })
     }
 
-    /// Add a fallback claim path, consulted only when every earlier path is absent or `null`.
+    /// Add a fallback claim path, consulted when every earlier path is absent, `null`, or
+    /// carries nothing.
     ///
-    /// The first present path decides the rule alone: with `none_of`, a banned value that
-    /// appears only in a fallback path is not seen when the primary path is present.
+    /// The first populated path decides the rule alone: with `none_of`, a banned value that
+    /// appears only in a fallback path is not seen when an earlier path is populated.
     ///
     /// # Errors
     /// [`ClaimRuleError::InvalidClaimPath`] if the path is empty, or nests on a dot with an
@@ -210,9 +223,13 @@ impl ClaimRule {
 
     /// Evaluate the rule against decoded claims.
     ///
-    /// The claim is the first path that is present and not `null`; if there is none it is
-    /// *missing*. A present claim is a set of values: a scalar is its canonical string, an
-    /// array of scalars is its elements, and strings are split by the separator. Objects and
+    /// The claim is chosen by [`resolve`]: the first path that is *populated*, falling back
+    /// to the first path that is present and not `null`; if there is none it is *missing*.
+    /// Preferring a populated path keeps an empty one — an `IdP` that emits `"scope": ""` —
+    /// from hiding a fallback that carries values, which would void a deny written over both.
+    ///
+    /// A present claim is a set of values: a scalar is its canonical string, an array of
+    /// scalars is its elements, and a grant splits strings by the separator. Objects and
     /// arrays holding non-scalars are *malformed*: they exist but carry no value.
     ///
     /// `exists: true` holds when the claim is *populated*: it carries at least one non-empty
@@ -220,35 +237,32 @@ impl ClaimRule {
     /// element. A claim that is present but empty (`[]`, `""`, `{}`) satisfies it no more
     /// than a missing one. `exists: false` keeps its narrow meaning of absent or `null`, so
     /// the two are not complements: an empty claim fails both.
+    /// The claim this rule reads, by the one rule every reader must use.
+    pub(crate) fn resolve<'a>(
+        &self,
+        claims: &'a serde_json::Value,
+    ) -> Option<&'a serde_json::Value> {
+        resolve(claims, self.claims.iter().map(String::as_str))
+    }
+
     #[must_use]
     pub fn matches(&self, claims: &serde_json::Value) -> bool {
-        let value = self
-            .claims
-            .iter()
-            .filter_map(|path| navigate(claims, path))
-            .find(|v| !v.is_null());
-        let items = value.and_then(scalars);
         let separator = self.separator.as_ref();
+        let value = self.resolve(claims);
+        let items = value.and_then(scalars);
         let values = || items.map(|(items, split)| ClaimValues::new(items, separator, split));
         match &self.operator {
-            ClaimOperator::Exists(true) => match value {
-                None => false,
-                // An object or an array of objects carries no comparable value, but it is
-                // still content: `exists` asks whether the claim is populated.
-                Some(serde_json::Value::Object(map)) => !map.is_empty(),
-                Some(serde_json::Value::Array(arr)) if items.is_none() => !arr.is_empty(),
-                Some(_) => values().is_some_and(|mut v| v.any(|x| !x.is_empty())),
-            },
+            ClaimOperator::Exists(true) => value.is_some_and(is_populated),
             ClaimOperator::Exists(false) => value.is_none(),
             ClaimOperator::AnyOf(set) => values().is_some_and(|mut v| v.any(|x| set.contains(&*x))),
-            // A deny holds only if no reading of the claim yields a banned value: both the
-            // values as the issuer wrote them and, when a separator is configured, the pieces
-            // it splits into — including inside array elements, which a grant never splits.
+            // A deny reads every item by position rather than by splitting, so no reading of
+            // the claim can yield a banned value — array elements included, which a grant
+            // never splits.
             ClaimOperator::NoneOf(set) => items.is_some_and(|(items, _)| {
-                let banned = |separator, split| {
-                    ClaimValues::new(items, separator, split).any(|x| set.contains(&*x))
-                };
-                !(banned(None, false) || (separator.is_some() && banned(separator, true)))
+                let lengths = needle_lengths(set);
+                !items
+                    .iter()
+                    .any(|item| is_banned(&scalar_text(item), set, &lengths, separator))
             }),
             // Splitting is the expensive part, so a multi-value `all_of` over a split string
             // splits once instead of once per needle.
@@ -264,6 +278,129 @@ impl ClaimRule {
             }),
         }
     }
+}
+
+/// The claim a set of paths reads: the first *populated* path, falling back to the first
+/// path that is present and not `null`.
+///
+/// Every reader of a claim — a rule, the scope requirement, [`Authentication::scopes`] — must
+/// resolve through here. A reader that resolves independently can end up guarding one claim
+/// while another is evaluated. Selection deliberately ignores the separator, so which claim
+/// is read is a property of the token rather than of how a rule happens to be formatted.
+///
+/// [`Authentication::scopes`]: crate::Authentication::scopes
+pub(crate) fn resolve<'a, 'p, I>(
+    claims: &'a serde_json::Value,
+    paths: I,
+) -> Option<&'a serde_json::Value>
+where
+    I: IntoIterator<Item = &'p str> + Clone,
+{
+    let present = |paths: I| {
+        paths
+            .into_iter()
+            .filter_map(|path| navigate(claims, path))
+            .filter(|v| !v.is_null())
+    };
+    // A present but empty path must not hide a later one that carries values, or an `IdP`
+    // that emits `"scope": ""` would void every deny written over a fallback. When no path is
+    // populated the first present one still decides, so `exists: false` keeps meaning absent
+    // or `null`.
+    present(paths.clone())
+        .find(|v| is_populated(v))
+        .or_else(|| present(paths).next())
+}
+
+/// Whether a claim carries content: at least one value that is not blank or, for a claim that
+/// is malformed and so carries no comparable value, at least one member or element.
+///
+/// Blank means empty or all whitespace. A whitespace-only claim states nothing, and saying so
+/// without consulting a separator keeps this a property of the data alone.
+fn is_populated(value: &serde_json::Value) -> bool {
+    match (value, scalars(value)) {
+        (_, Some((items, _))) => items.iter().any(|v| !scalar_text(v).trim().is_empty()),
+        (serde_json::Value::Object(map), None) => !map.is_empty(),
+        (serde_json::Value::Array(items), None) => !items.is_empty(),
+        (_, None) => false,
+    }
+}
+
+/// The distinct byte lengths a banned value can have, shortest first.
+fn needle_lengths(set: &HashSet<String>) -> Vec<usize> {
+    let mut lengths: Vec<usize> = set.iter().map(String::len).collect();
+    lengths.sort_unstable();
+    lengths.dedup();
+    lengths
+}
+
+/// The comparable text of a scalar item.
+fn scalar_text(value: &serde_json::Value) -> Cow<'_, str> {
+    match value {
+        serde_json::Value::String(s) => Cow::Borrowed(s),
+        other => Cow::Owned(other.to_string()),
+    }
+}
+
+/// Whether `item` carries a value the deny set names.
+///
+/// A value is *delimited* when it runs from the start of the item or a separator to the end
+/// of the item or a separator. Splitting cannot decide this: [`str::split`] is exact and
+/// non-overlapping, so an item ending in a proper prefix of a multi-character separator
+/// shifts every boundary after it — `"a:::admin".split("::")` yields `["a", ":admin"]` and
+/// never produces `admin`, hiding a banned group from the deny. Scanning from every position
+/// a value could start at sees all readings, so no join can smuggle a banned value through.
+///
+/// `lengths` are the distinct lengths of the deny set, so each position costs one lookup per
+/// length rather than one comparison per banned value.
+fn is_banned(
+    item: &str,
+    set: &HashSet<String>,
+    lengths: &[usize],
+    separator: Option<&Separator>,
+) -> bool {
+    if set.contains(item) {
+        return true;
+    }
+    // Without a separator in the item there is one position and one length that can be
+    // delimited: the whole item, already tested above.
+    let Some(separator) = separator.filter(|s| contains_separator(item, s)) else {
+        return false;
+    };
+    let banned_at = |start: usize| {
+        lengths.iter().any(|&len| {
+            item.get(start..start + len).is_some_and(|value| {
+                set.contains(value) && ends_delimited(item, start + len, separator)
+            })
+        })
+    };
+    banned_at(0)
+        || match separator {
+            Separator::Whitespace => item
+                .char_indices()
+                .filter(|(_, c)| c.is_whitespace())
+                .any(|(i, c)| banned_at(i + c.len_utf8())),
+            // Overlapping occurrences count: `":::"` starts a value at two offsets.
+            Separator::Literal(sep) => (0..item.len())
+                .filter(|&i| item.is_char_boundary(i) && item[i..].starts_with(sep.as_str()))
+                .any(|i| banned_at(i + sep.len())),
+        }
+}
+
+/// Whether the separator occurs in `item` at all.
+fn contains_separator(item: &str, separator: &Separator) -> bool {
+    match separator {
+        Separator::Whitespace => item.contains(char::is_whitespace),
+        Separator::Literal(sep) => item.contains(sep.as_str()),
+    }
+}
+
+/// Whether a value ending at `end` is closed by the end of the item or by a separator.
+fn ends_delimited(item: &str, end: usize, separator: &Separator) -> bool {
+    end == item.len()
+        || match separator {
+            Separator::Whitespace => item[end..].starts_with(char::is_whitespace),
+            Separator::Literal(sep) => item[end..].starts_with(sep.as_str()),
+        }
 }
 
 /// The scalar items of a claim value: the value itself, or the elements of an array of
@@ -454,14 +591,21 @@ mod tests {
         );
         // `with_separator` revalidates values against the separator.
         assert_eq!(
-            ClaimRule::none_of("groups", ["Domain Admins"])
+            ClaimRule::any_of("groups", ["Domain Admins"])
                 .unwrap()
                 .with_separator(Separator::Whitespace)
                 .unwrap_err(),
             ClaimRuleError::ValueContainsSeparator {
-                operator: "none_of",
+                operator: "any_of",
                 value: "Domain Admins".to_string(),
             }
+        );
+        // A deny may name such a value: it is read by position, not by splitting.
+        assert!(
+            ClaimRule::none_of("groups", ["Domain Admins"])
+                .unwrap()
+                .with_separator(Separator::Whitespace)
+                .is_ok()
         );
         // The separator survives `or_claim`.
         assert_eq!(
@@ -557,16 +701,16 @@ mod tests {
     }
 
     #[test]
-    fn new_rejects_values_the_separator_would_split() {
+    fn new_rejects_grant_values_the_separator_would_split() {
         assert_eq!(
             ClaimRule::new(
                 "groups",
                 Some(Separator::Whitespace),
-                none_of(&["Domain Admins"])
+                all_of(&["Domain Admins"])
             )
             .unwrap_err(),
             ClaimRuleError::ValueContainsSeparator {
-                operator: "none_of",
+                operator: "all_of",
                 value: "Domain Admins".to_string(),
             }
         );
@@ -578,6 +722,11 @@ mod tests {
                 value: "a,b".to_string(),
             }
         );
+        // A deny may name a value containing the separator, and denies it.
+        let r =
+            ClaimRule::new("c", Some(Separator::Literal(",".into())), none_of(&["a,b"])).unwrap();
+        assert!(!r.matches(&serde_json::json!({ "c": "x,a,b" })));
+        assert!(r.matches(&serde_json::json!({ "c": "x,ab" })));
         // Without a separator a value may contain anything.
         assert!(ClaimRule::new("c", None, none_of(&["Domain Admins"])).is_ok());
     }
@@ -942,6 +1091,256 @@ mod tests {
 
     /// A deny must not be evadable by embedding the banned value in an array element, even
     /// though a grant deliberately refuses to split those elements.
+    /// `str::split` is exact and non-overlapping, so an item ending in a proper prefix of a
+    /// multi-character separator shifts every later boundary. Reading by position instead of
+    /// by splitting denies the value under every join the issuer could have produced.
+    #[test]
+    fn none_of_denies_across_a_shifted_multi_character_separator() {
+        // `"a:::admin".split("::")` is `["a", ":admin"]` — `admin` is never produced.
+        assert_eq!("a:::admin".split("::").collect::<Vec<_>>(), ["a", ":admin"]);
+        let r = rule_sep("c", Separator::Literal("::".into()), none_of(&["admin"]));
+        // Denied whichever side the shifting group sits on.
+        assert!(!r.matches(&serde_json::json!({ "c": "a:::admin" })));
+        assert!(!r.matches(&serde_json::json!({ "c": "admin::a:" })));
+        assert!(!r.matches(&serde_json::json!({ "c": ["x", "a:::admin"] })));
+        // A value that is not delimited is still not a value.
+        assert!(r.matches(&serde_json::json!({ "c": "a:::xadmin" })));
+        assert!(r.matches(&serde_json::json!({ "c": "superadmin" })));
+
+        let r = rule_sep("c", Separator::Literal("--".into()), none_of(&["admin"]));
+        assert!(!r.matches(&serde_json::json!({ "c": "eng---admin" })));
+        assert!(r.matches(&serde_json::json!({ "c": "eng-admin" })));
+    }
+
+    /// A banned value must be closed on the right too, or the deny degrades to a substring
+    /// match and refuses values that merely start with one.
+    #[test]
+    fn none_of_admits_a_value_that_only_starts_with_a_banned_one() {
+        let literal = rule_sep("c", Separator::Literal("::".into()), none_of(&["admin"]));
+        assert!(literal.matches(&serde_json::json!({ "c": "x::adminx" })));
+        assert!(!literal.matches(&serde_json::json!({ "c": "x::admin" })));
+        let whitespace = rule_sep("c", Separator::Whitespace, none_of(&["admin"]));
+        assert!(whitespace.matches(&serde_json::json!({ "c": "x adminx" })));
+        assert!(!whitespace.matches(&serde_json::json!({ "c": "x admin" })));
+    }
+
+    /// Scanning for a literal separator walks byte offsets, so a multi-byte character must
+    /// not be sliced through.
+    #[test]
+    fn none_of_scans_multi_byte_items_without_slicing_a_character() {
+        let r = rule_sep("c", Separator::Literal(":".into()), none_of(&["user"]));
+        assert!(!r.matches(&serde_json::json!({ "c": "café:user" })));
+        assert!(r.matches(&serde_json::json!({ "c": "café:users" })));
+        let r = rule_sep("c", Separator::Literal("é".into()), none_of(&["user"]));
+        assert!(!r.matches(&serde_json::json!({ "c": "caféuser" })));
+    }
+
+    /// Every value a deny must catch, checked against an oracle that enumerates the joins an
+    /// issuer could have written. Splitting misses the shifted ones; scanning by position
+    /// does not.
+    #[test]
+    fn none_of_agrees_with_an_oracle_over_every_short_join() {
+        let sep = "::";
+        let atoms = ["a", ":", "admin", "ad"];
+        let r = rule_sep("c", Separator::Literal(sep.into()), none_of(&["admin"]));
+        let mut checked = 0_u32;
+        for len in 1..=3 {
+            let mut idx = vec![0_usize; len];
+            loop {
+                let parts: Vec<&str> = idx.iter().map(|&i| atoms[i]).collect();
+                let joined = parts.join(sep);
+                // The oracle knows what the issuer put in the token. Only the `admin` atom
+                // contains that substring, so the deny must fire exactly when it was joined
+                // in — asserting both directions, or half the cases would assert nothing.
+                let expected_denied = parts.contains(&"admin");
+                assert_eq!(
+                    !r.matches(&serde_json::json!({ "c": joined })),
+                    expected_denied,
+                    "{joined:?} joins {parts:?}"
+                );
+                checked += 1;
+                let mut i = len;
+                loop {
+                    if i == 0 {
+                        break;
+                    }
+                    i -= 1;
+                    idx[i] += 1;
+                    if idx[i] < atoms.len() {
+                        break;
+                    }
+                    idx[i] = 0;
+                    if i == 0 {
+                        break;
+                    }
+                }
+                if idx.iter().all(|&i| i == 0) {
+                    break;
+                }
+            }
+        }
+        assert_eq!(checked, 84);
+    }
+
+    /// An empty primary claim must not hide a fallback carrying a banned value. A populated
+    /// primary still decides alone — that is the documented `or_claim` rule, not a fail-open,
+    /// since which claim is read must not depend on what the deny happens to list.
+    #[test]
+    fn an_empty_path_does_not_hide_a_fallback_that_carries_a_banned_value() {
+        let r = ClaimRule::none_of("scope", ["banned"])
+            .unwrap()
+            .with_separator(Separator::Whitespace)
+            .unwrap()
+            .or_claim("scp")
+            .unwrap();
+        for primary in [
+            serde_json::json!(""),
+            serde_json::json!([]),
+            serde_json::json!("   "),
+            serde_json::json!({}),
+            serde_json::json!(null),
+        ] {
+            let claims = serde_json::json!({ "scope": primary, "scp": ["banned"] });
+            assert!(!r.matches(&claims), "{claims} must be denied");
+        }
+        // A populated primary still decides alone, which is the documented `or_claim` rule.
+        let claims = serde_json::json!({ "scope": "read", "scp": ["banned"] });
+        assert!(r.matches(&claims));
+    }
+
+    /// Preferring a populated path widens grants as well as denies: a token whose values sit
+    /// in the fallback now satisfies a rule the empty primary would have failed.
+    #[test]
+    fn an_empty_path_does_not_hide_a_fallback_that_carries_a_wanted_value() {
+        let any = ClaimRule::any_of("a", ["admin"])
+            .unwrap()
+            .or_claim("b")
+            .unwrap();
+        let all = ClaimRule::all_of("a", ["admin"])
+            .unwrap()
+            .or_claim("b")
+            .unwrap();
+        for empty in [json!(""), json!("   "), json!([]), json!([""]), json!({})] {
+            let claims = json!({ "a": empty, "b": ["admin"] });
+            assert!(any.matches(&claims), "{claims} must satisfy any_of");
+            assert!(all.matches(&claims), "{claims} must satisfy all_of");
+        }
+        // A populated primary still decides alone.
+        let claims = json!({ "a": "other", "b": ["admin"] });
+        assert!(!any.matches(&claims));
+        assert!(!all.matches(&claims));
+    }
+
+    /// Which claim is read must not depend on how a rule is formatted.
+    #[test]
+    fn path_selection_ignores_the_separator() {
+        for primary in [json!("   "), json!(["   "]), json!(""), json!("x y")] {
+            let claims = json!({ "a": primary, "b": ["admin"] });
+            let plain = ClaimRule::any_of("a", ["admin"])
+                .unwrap()
+                .or_claim("b")
+                .unwrap();
+            let split = ClaimRule::any_of("a", ["admin"])
+                .unwrap()
+                .with_separator(Separator::Whitespace)
+                .unwrap()
+                .or_claim("b")
+                .unwrap();
+            assert_eq!(
+                plain.resolve(&claims),
+                split.resolve(&claims),
+                "{claims}: the separator changed which claim is read"
+            );
+        }
+    }
+
+    /// Preferring a populated path must not widen `exists: false`, which stays absent-or-null.
+    #[test]
+    fn an_empty_path_is_still_present_for_exists() {
+        for empty in [
+            serde_json::json!(""),
+            serde_json::json!([]),
+            serde_json::json!({}),
+        ] {
+            let claims = serde_json::json!({ "scope": empty, "scp": [] });
+            let r = ClaimRule::exists("scope", false)
+                .unwrap()
+                .or_claim("scp")
+                .unwrap();
+            assert!(
+                !r.matches(&claims),
+                "{claims} is present, so exists=false must fail"
+            );
+            let r = ClaimRule::exists("scope", true)
+                .unwrap()
+                .or_claim("scp")
+                .unwrap();
+            assert!(
+                !r.matches(&claims),
+                "{claims} is empty, so exists=true must fail"
+            );
+        }
+    }
+
+    /// Every operator against every degenerate claim shape, with and without a separator.
+    ///
+    /// Each fail-open found so far was a shape whose evaluation fell through to "admit". The
+    /// table states the outcome of all of them at once, so a change that flips one is visible
+    /// in the diff rather than only in a rule nobody wrote a test for. Columns are
+    /// `any_of ["admin"]`, `all_of ["admin"]`, `none_of ["admin"]`, `exists true`,
+    /// `exists false`; `none_of` is listed as it evaluates, so `false` there means *denied*.
+    #[test]
+    fn every_operator_over_every_degenerate_claim_shape() {
+        const T: bool = true;
+        const F: bool = false;
+        // shape,            no separator,        whitespace separator
+        let table: &[(Option<serde_json::Value>, [bool; 5], [bool; 5])] = &[
+            (None, [F, F, F, F, T], [F, F, F, F, T]),
+            (Some(json!(null)), [F, F, F, F, T], [F, F, F, F, T]),
+            (Some(json!("")), [F, F, T, F, F], [F, F, T, F, F]),
+            // Blank is not content, and a lone string and a one-element array agree, since
+            // neither answer consults the separator.
+            (Some(json!("   ")), [F, F, T, F, F], [F, F, T, F, F]),
+            (Some(json!(["   "])), [F, F, T, F, F], [F, F, T, F, F]),
+            (Some(json!([])), [F, F, T, F, F], [F, F, T, F, F]),
+            (Some(json!({})), [F, F, F, F, F], [F, F, F, F, F]),
+            (Some(json!({"k": "v"})), [F, F, F, T, F], [F, F, F, T, F]),
+            (Some(json!([""])), [F, F, T, F, F], [F, F, T, F, F]),
+            (Some(json!([null])), [F, F, F, T, F], [F, F, F, T, F]),
+            (Some(json!([{}])), [F, F, F, T, F], [F, F, F, T, F]),
+            (Some(json!("admin")), [T, T, F, T, F], [T, T, F, T, F]),
+            (Some(json!(["admin"])), [T, T, F, T, F], [T, T, F, T, F]),
+            // A grant reads one value; a deny sees the banned value between delimiters.
+            (Some(json!("x admin")), [F, F, T, T, F], [T, T, F, T, F]),
+            // An array element is never split for a grant, but a deny still sees inside it.
+            (Some(json!(["x admin"])), [F, F, T, T, F], [F, F, F, T, F]),
+            (Some(json!(42)), [F, F, T, T, F], [F, F, T, T, F]),
+            (Some(json!(true)), [F, F, T, T, F], [F, F, T, T, F]),
+        ];
+        let operators = || {
+            [
+                any_of(&["admin"]),
+                all_of(&["admin"]),
+                none_of(&["admin"]),
+                ClaimOperator::Exists(true),
+                ClaimOperator::Exists(false),
+            ]
+        };
+        for (shape, without, with) in table {
+            let claims = shape.as_ref().map_or_else(
+                || json!({ "other": "x" }),
+                |v| json!({ "c": v, "other": "x" }),
+            );
+            for (separator, expected) in [(None, without), (Some(Separator::Whitespace), with)] {
+                for (operator, expected) in operators().into_iter().zip(expected) {
+                    let label = format!("{shape:?} {operator:?} sep={separator:?}");
+                    let rule = ClaimRule::new("c", separator.clone(), operator).unwrap();
+                    assert_eq!(rule.matches(&claims), *expected, "{label}");
+                }
+            }
+        }
+    }
+
     #[test]
     fn none_of_denies_a_banned_value_inside_an_array_element() {
         let smuggled = claims_with(&json!(["x,admin"]));
@@ -957,6 +1356,14 @@ mod tests {
         assert!(!deny.matches(&claims_with(&json!(["admin"]))));
         // An unrelated claim still passes the deny.
         assert!(deny.matches(&claims_with(&json!(["users"]))));
+
+        // The same holds for whitespace, the separator `scope` is configured with.
+        let deny = rule_sep("c", Separator::Whitespace, none_of(&["admin"]));
+        assert!(!deny.matches(&claims_with(&json!(["x admin"]))));
+        assert!(!deny.matches(&claims_with(&json!("x admin"))));
+        assert!(deny.matches(&claims_with(&json!(["xadmin"]))));
+        let grant = rule_sep("c", Separator::Whitespace, any_of(&["admin"]));
+        assert!(!grant.matches(&claims_with(&json!(["x admin"]))));
     }
 
     #[test]

--- a/crates/limes/src/claims.rs
+++ b/crates/limes/src/claims.rs
@@ -423,9 +423,9 @@ fn is_banned(
                 .filter(|(_, c)| c.is_whitespace())
                 .any(|(i, c)| banned_at(i + c.len_utf8())),
             // Overlapping occurrences count: `":::"` starts a value at two offsets.
-            Separator::Literal(sep) => (0..item.len())
-                .filter(|&i| item.is_char_boundary(i) && item[i..].starts_with(sep.as_str()))
-                .any(|i| banned_at(i + sep.len())),
+            Separator::Literal(literal) => (0..item.len())
+                .filter(|&i| item.is_char_boundary(i) && item[i..].starts_with(literal.as_str()))
+                .any(|i| banned_at(i + literal.len())),
         }
 }
 

--- a/crates/limes/src/claims.rs
+++ b/crates/limes/src/claims.rs
@@ -1067,9 +1067,6 @@ mod tests {
         let null_flat = json!({ "a.b": null, "a": { "b": "real" } });
         assert!(rule("a.b", ClaimOperator::Exists(true)).matches(&null_flat));
         assert!(!rule("a.b", ClaimOperator::Exists(false)).matches(&null_flat));
-
-        // Consequence: a URI-shaped claim name is not addressable; such a path is rejected
-        // at construction (see `new_rejects_uri_shaped_claim_paths`).
     }
 
     /// Pins the documented `none_of` semantics: without a separator the whole string is one

--- a/crates/limes/src/claims.rs
+++ b/crates/limes/src/claims.rs
@@ -39,7 +39,10 @@ pub enum ClaimOperator {
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
 pub enum ClaimRuleError {
-    #[error("claim path must not be empty or contain empty segments")]
+    #[error(
+        "claim path must not be empty, contain empty segments, or contain `/` or `:` \
+         (a claim whose name contains a dot, such as a URI, is not addressable)"
+    )]
     InvalidClaimPath,
     #[error("{operator} must not be empty")]
     EmptyValueList { operator: &'static str },
@@ -196,7 +199,12 @@ impl ClaimRule {
     /// The claim is the first path that is present and not `null`; if there is none it is
     /// *missing*. A present claim is a set of values: a scalar is its canonical string, an
     /// array of scalars is its elements, and strings are split by the separator. Objects and
-    /// arrays holding non-scalars are *malformed*: they exist but match no value.
+    /// arrays holding non-scalars are *malformed*: they exist but carry no value.
+    ///
+    /// `exists: true` holds when the claim carries at least one non-empty value, so a claim
+    /// that is present but empty — `[]`, `""`, `{}` — satisfies it no more than a missing
+    /// one. `exists: false` keeps its narrow meaning of absent or `null`, so the two are not
+    /// complements: an empty claim fails both.
     #[must_use]
     pub fn matches(&self, claims: &serde_json::Value) -> bool {
         let value = self
@@ -206,16 +214,25 @@ impl ClaimRule {
             .find(|v| !v.is_null());
         let items = value.and_then(scalars);
         let separator = self.separator.as_ref();
-        let values = || items.map(|items| ClaimValues::new(items, separator));
+        let values = || items.map(|(items, split)| ClaimValues::new(items, separator, split));
         match &self.operator {
-            ClaimOperator::Exists(expected) => value.is_some() == *expected,
+            ClaimOperator::Exists(true) => values().is_some_and(|mut v| v.any(|x| !x.is_empty())),
+            ClaimOperator::Exists(false) => value.is_none(),
             ClaimOperator::AnyOf(set) => values().is_some_and(|mut v| v.any(|x| set.contains(&*x))),
             ClaimOperator::NoneOf(set) => {
                 values().is_some_and(|mut v| !v.any(|x| set.contains(&*x)))
             }
-            ClaimOperator::AllOf(set) => items.is_some_and(|items| {
+            // Splitting is the expensive part, so a multi-value `all_of` over a split string
+            // splits once instead of once per needle.
+            ClaimOperator::AllOf(set) if separator.is_some() && set.len() > 1 => values()
+                .is_some_and(|v| {
+                    let values: Vec<_> = v.collect();
+                    set.iter()
+                        .all(|needle| values.iter().any(|x| **x == **needle))
+                }),
+            ClaimOperator::AllOf(set) => items.is_some_and(|(items, split)| {
                 set.iter()
-                    .all(|needle| ClaimValues::new(items, separator).any(|x| *x == **needle))
+                    .all(|needle| ClaimValues::new(items, separator, split).any(|x| *x == **needle))
             }),
         }
     }
@@ -223,22 +240,25 @@ impl ClaimRule {
 
 /// The scalar items of a claim value: the value itself, or the elements of an array of
 /// scalars. `None` for objects and arrays holding non-scalars.
-pub(crate) fn scalars(value: &serde_json::Value) -> Option<&[serde_json::Value]> {
+///
+/// The flag reports whether the claim was a lone scalar rather than an array, which is the
+/// only case a separator may split.
+pub(crate) fn scalars(value: &serde_json::Value) -> Option<(&[serde_json::Value], bool)> {
     match value {
-        serde_json::Value::Array(items) if items.iter().all(is_scalar) => Some(items),
-        v if is_scalar(v) => Some(std::slice::from_ref(v)),
+        serde_json::Value::Array(items) if items.iter().all(is_scalar) => Some((items, false)),
+        v if is_scalar(v) => Some((std::slice::from_ref(v), true)),
         _ => None,
     }
 }
 
 /// Like [`scalars`], but only a string or an array of strings qualifies; numbers and booleans
 /// make the claim malformed. Used for scopes, which are strings by definition.
-pub(crate) fn strings(value: &serde_json::Value) -> Option<&[serde_json::Value]> {
+pub(crate) fn strings(value: &serde_json::Value) -> Option<(&[serde_json::Value], bool)> {
     match value {
         serde_json::Value::Array(items) if items.iter().all(serde_json::Value::is_string) => {
-            Some(items)
+            Some((items, false))
         }
-        serde_json::Value::String(_) => Some(std::slice::from_ref(value)),
+        serde_json::Value::String(_) => Some((std::slice::from_ref(value), true)),
         _ => None,
     }
 }
@@ -252,7 +272,10 @@ fn collect<I: IntoIterator<Item = S>, S: Into<String>>(values: I) -> HashSet<Str
 }
 
 fn validate_path(path: String) -> Result<String, ClaimRuleError> {
-    if path.is_empty() || path.split('.').any(str::is_empty) {
+    // `/` and `:` only appear in URI-shaped claim *names*, which dotted paths cannot address.
+    // Such a path resolves to nothing, which `exists: false` would read as "holds for every
+    // token" — so reject it rather than let a rule silently admit everyone.
+    if path.is_empty() || path.split('.').any(str::is_empty) || path.contains(['/', ':']) {
         return Err(ClaimRuleError::InvalidClaimPath);
     }
     Ok(path)
@@ -260,6 +283,10 @@ fn validate_path(path: String) -> Result<String, ClaimRuleError> {
 
 /// Streams the comparable values of scalar items without collecting: strings are borrowed
 /// (and split by the separator, empty pieces dropped), numbers and booleans are formatted.
+///
+/// The separator applies only when the claim is a lone string. An array already states one
+/// value per element, so splitting its elements would manufacture values the issuer never
+/// put in the token — `["x,admin"]` must not satisfy a rule for `admin`.
 pub(crate) struct ClaimValues<'a> {
     items: std::slice::Iter<'a, serde_json::Value>,
     separator: Option<&'a Separator>,
@@ -272,10 +299,15 @@ enum Pieces<'a> {
 }
 
 impl<'a> ClaimValues<'a> {
-    pub(crate) fn new(items: &'a [serde_json::Value], separator: Option<&'a Separator>) -> Self {
+    /// `separator` is applied only if `items` is a lone string claim, not array elements.
+    pub(crate) fn new(
+        items: &'a [serde_json::Value],
+        separator: Option<&'a Separator>,
+        split: bool,
+    ) -> Self {
         Self {
             items: items.iter(),
-            separator,
+            separator: if split { separator } else { None },
             pending: None,
         }
     }
@@ -415,6 +447,28 @@ mod tests {
         );
     }
 
+    /// An unresolvable path makes `exists: false` hold for every token, so paths that can
+    /// only ever be claim *names* — not addressable as dotted paths — are rejected up front.
+    #[test]
+    fn new_rejects_uri_shaped_claim_paths() {
+        for path in [
+            "https://example.com/roles",
+            "kubernetes.io/serviceaccount/namespace",
+            "http://schemas.microsoft.com/identity/claims/objectidentifier",
+        ] {
+            assert_eq!(
+                ClaimRule::new(path, None, any_of(&["a"])).unwrap_err(),
+                ClaimRuleError::InvalidClaimPath,
+                "path {path:?}"
+            );
+            assert_eq!(
+                ClaimRule::new(path, None, ClaimOperator::Exists(false)).unwrap_err(),
+                ClaimRuleError::InvalidClaimPath,
+                "path {path:?}"
+            );
+        }
+    }
+
     #[test]
     fn new_rejects_empty_path_segments() {
         for path in ["a..b", ".a", "a.", "."] {
@@ -540,7 +594,7 @@ mod tests {
         assert!(!r(all_of(&["a"])).matches(&claims));
         // Like an empty array: present, nothing to deny.
         assert!(r(none_of(&["a"])).matches(&claims));
-        assert!(r(ClaimOperator::Exists(true)).matches(&claims));
+        assert!(!r(ClaimOperator::Exists(true)).matches(&claims));
     }
 
     #[test]
@@ -554,28 +608,56 @@ mod tests {
         assert!(!rule("c", none_of(&["a"])).matches(&claims));
     }
 
+    /// `exists: true` asks whether the claim carries a value, so the wire form of
+    /// "belongs to nothing" — an empty array or an empty string — does not satisfy it.
+    /// `exists: false` keeps its narrow meaning (absent or `null`), so the two are not
+    /// complements: both reject a claim that is present but carries nothing.
     #[test]
-    fn empty_array_matches_nothing_but_exists() {
+    fn empty_array_matches_no_operator() {
         let claims = claims_with(&json!([]));
         assert!(!rule("c", any_of(&["a"])).matches(&claims));
         assert!(!rule("c", all_of(&["a"])).matches(&claims));
         assert!(rule("c", none_of(&["a"])).matches(&claims));
-        assert!(rule("c", ClaimOperator::Exists(true)).matches(&claims));
+        assert!(!rule("c", ClaimOperator::Exists(true)).matches(&claims));
         assert!(!rule("c", ClaimOperator::Exists(false)).matches(&claims));
     }
 
     #[test]
-    fn object_claim_fails_every_operator_except_exists_true() {
+    fn exists_true_requires_a_non_empty_value() {
+        for empty in [json!([]), json!(""), json!({}), json!(["", ""])] {
+            let claims = claims_with(&empty);
+            assert!(
+                !rule("c", ClaimOperator::Exists(true)).matches(&claims),
+                "{empty} must not satisfy exists=true"
+            );
+            assert!(
+                !rule("c", ClaimOperator::Exists(false)).matches(&claims),
+                "{empty} is present, so exists=false must not hold either"
+            );
+        }
+        for present in [json!("a"), json!(0), json!(false), json!(["a"])] {
+            let claims = claims_with(&present);
+            assert!(
+                rule("c", ClaimOperator::Exists(true)).matches(&claims),
+                "{present} must satisfy exists=true"
+            );
+        }
+    }
+
+    /// An object carries no comparable value, so it satisfies no operator — including
+    /// `exists`, which would otherwise report a claim no rule can act on as usable.
+    #[test]
+    fn object_claim_fails_every_operator() {
         let claims = claims_with(&json!({"a": "b"}));
         assert!(!rule("c", any_of(&["a"])).matches(&claims));
         assert!(!rule("c", all_of(&["a"])).matches(&claims));
         assert!(!rule("c", none_of(&["zzz"])).matches(&claims));
-        assert!(rule("c", ClaimOperator::Exists(true)).matches(&claims));
+        assert!(!rule("c", ClaimOperator::Exists(true)).matches(&claims));
         assert!(!rule("c", ClaimOperator::Exists(false)).matches(&claims));
     }
 
     #[test]
-    fn array_with_non_scalar_element_fails_every_operator_except_exists_true() {
+    fn array_with_non_scalar_element_fails_every_operator() {
         for value in [
             json!(["a", ["b"]]),
             json!(["a", {"k": "v"}]),
@@ -583,8 +665,10 @@ mod tests {
         ] {
             let claims = claims_with(&value);
             assert!(!rule("c", any_of(&["a"])).matches(&claims));
+            assert!(!rule("c", all_of(&["a"])).matches(&claims));
             assert!(!rule("c", none_of(&["zzz"])).matches(&claims));
-            assert!(rule("c", ClaimOperator::Exists(true)).matches(&claims));
+            assert!(!rule("c", ClaimOperator::Exists(true)).matches(&claims));
+            assert!(!rule("c", ClaimOperator::Exists(false)).matches(&claims));
         }
     }
 
@@ -608,9 +692,9 @@ mod tests {
     }
 
     #[test]
-    fn empty_string_claim_exists() {
+    fn empty_string_claim_carries_no_value() {
         let claims = claims_with(&json!(""));
-        assert!(rule("c", ClaimOperator::Exists(true)).matches(&claims));
+        assert!(!rule("c", ClaimOperator::Exists(true)).matches(&claims));
         assert!(!rule("c", any_of(&["a"])).matches(&claims));
     }
 
@@ -659,15 +743,28 @@ mod tests {
         assert!(r.matches(&claims));
     }
 
+    /// An array states one value per element. Splitting elements would manufacture values
+    /// the issuer never put in the token, so a rule for `admin` must not match
+    /// `["x,admin"]`.
     #[test]
-    fn separator_applies_to_each_string_array_element() {
+    fn separator_does_not_split_array_elements() {
         let claims = claims_with(&json!(["openid email", "profile"]));
         let r = rule_sep(
             "c",
             Separator::Whitespace,
             all_of(&["openid", "email", "profile"]),
         );
-        assert!(r.matches(&claims));
+        assert!(!r.matches(&claims));
+        // Unsplit, each element is one value — matched by a rule without a separator.
+        assert!(rule("c", all_of(&["openid email", "profile"])).matches(&claims));
+
+        let smuggled = claims_with(&json!(["x,platform-admins"]));
+        let r = rule_sep(
+            "c",
+            Separator::Literal(",".into()),
+            any_of(&["platform-admins"]),
+        );
+        assert!(!r.matches(&smuggled));
     }
 
     #[test]
@@ -702,14 +799,12 @@ mod tests {
         assert!(!rule("realm_access.roles", none_of(&["banned"])).matches(&attack));
 
         // A `null` flat key cannot hide the nested claim from `exists`.
-        let null_flat = json!({ "a.b": null, "a": { "b": "real" } });
+        let null_flat = json!({ "a": { "b": "real" } });
         assert!(rule("a.b", ClaimOperator::Exists(true)).matches(&null_flat));
         assert!(!rule("a.b", ClaimOperator::Exists(false)).matches(&null_flat));
 
-        // Consequence: a URI-shaped claim name is not addressable.
-        let uri = json!({ "https://example.com/roles": ["admin"] });
-        assert!(!rule("https://example.com/roles", any_of(&["admin"])).matches(&uri));
-        assert!(!rule("https://example.com/roles", ClaimOperator::Exists(true)).matches(&uri));
+        // Consequence: a URI-shaped claim name is not addressable; such a path is rejected
+        // at construction (see `new_rejects_uri_shaped_claim_paths`).
     }
 
     /// Pins the documented `none_of` semantics: without a separator the whole string is one
@@ -758,6 +853,18 @@ mod tests {
             .unwrap();
         assert!(r.matches(&json!({})));
         assert!(!r.matches(&json!({ "scp": "x" })));
+    }
+
+    /// A multi-value `all_of` takes the split-once path; it must agree with the general one.
+    #[test]
+    fn all_of_over_a_split_string_matches_every_value() {
+        let claims = claims_with(&json!("a b c"));
+        let r = |v: &[&str]| rule_sep("c", Separator::Whitespace, all_of(v));
+        assert!(r(&["a", "b"]).matches(&claims));
+        assert!(r(&["a", "b", "c"]).matches(&claims));
+        assert!(!r(&["a", "z"]).matches(&claims));
+        assert!(!r(&["a", "b", "c", "d"]).matches(&claims));
+        assert!(r(&["a"]).matches(&claims));
     }
 
     #[test]

--- a/crates/limes/src/error.rs
+++ b/crates/limes/src/error.rs
@@ -11,6 +11,17 @@ pub enum RejectionReason {
     AudienceMismatch,
     /// The `iss` claim matched none of the accepted issuers.
     IssuerMismatch,
+    /// A claim required for validation is absent, or is not of the type its specification
+    /// requires. Named by the JWT specification (`aud`, `iss`, `exp`, …), never by the token.
+    ClaimMissing { claim: String },
+    /// The `exp` claim lies in the past.
+    Expired,
+    /// The `nbf` claim lies in the future. Commonly clock drift between the identity
+    /// provider and this host rather than a bad token.
+    NotYetValid,
+    /// A registered claim is present but not of the type its specification requires. The
+    /// claim is named by the JWT specification, never by the token.
+    ClaimMalformed { claim: String },
     /// The scope required by `set_scope` is not present.
     ScopeMissing,
     /// The named required-claim rule did not hold.
@@ -26,6 +37,12 @@ impl std::fmt::Display for RejectionReason {
         match self {
             Self::AudienceMismatch => f.write_str("audience is not accepted"),
             Self::IssuerMismatch => f.write_str("issuer is not accepted"),
+            Self::ClaimMissing { claim } => write!(f, "claim `{claim}` is missing"),
+            Self::Expired => f.write_str("token has expired"),
+            Self::NotYetValid => {
+                f.write_str("token is not valid yet; check the clocks of this host and the issuer")
+            }
+            Self::ClaimMalformed { claim } => write!(f, "claim `{claim}` is malformed"),
             Self::ScopeMissing => f.write_str("required scope is missing"),
             Self::ClaimRuleFailed { rule } => write!(f, "required-claim rule `{rule}` failed"),
             Self::SubjectClaimMissing => f.write_str("subject claim is missing"),

--- a/crates/limes/src/error.rs
+++ b/crates/limes/src/error.rs
@@ -11,16 +11,19 @@ pub enum RejectionReason {
     AudienceMismatch,
     /// The `iss` claim matched none of the accepted issuers.
     IssuerMismatch,
-    /// A claim required for validation is absent, or is not of the type its specification
-    /// requires. Named by the JWT specification (`aud`, `iss`, `exp`, …), never by the token.
+    /// A claim required for validation is absent, or is present but fails to parse as the
+    /// type its specification requires — the two are indistinguishable at this layer. Named
+    /// by the JWT specification (`aud`, `iss`, `exp`, …), never by the token.
     ClaimMissing { claim: String },
     /// The `exp` claim lies in the past.
     Expired,
     /// The `nbf` claim lies in the future. Commonly clock drift between the identity
     /// provider and this host rather than a bad token.
     NotYetValid,
-    /// A registered claim is present but not of the type its specification requires. The
-    /// claim is named by the JWT specification, never by the token.
+    /// A claim is present but not of the type its specification requires, and is not one of
+    /// the claims required for validation — in practice only `nbf`, since a required claim
+    /// that fails to parse is reported as [`ClaimMissing`](Self::ClaimMissing). The claim is
+    /// named by the JWT specification, never by the token.
     ClaimMalformed { claim: String },
     /// The scope required by `set_scope` is not present.
     ScopeMissing,

--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -1287,7 +1287,11 @@ mod test {
     fn test_unsatisfiable_scopes_are_rejected_at_construction() {
         assert_eq!(
             ScopeRule::new(String::new()).unwrap_err().to_string(),
-            "Invalid scope: all_of must not contain empty strings"
+            "Invalid scope: all_of must not contain blank values"
+        );
+        assert_eq!(
+            ScopeRule::new("   ".to_string()).unwrap_err().to_string(),
+            "Invalid scope: all_of must not contain blank values"
         );
         assert_eq!(
             ScopeRule::new("read write".to_string())

--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -117,6 +117,24 @@ impl JWKSWebAuthenticator {
         self
     }
 
+    /// The issuers this authenticator accepts: the one discovered from the provider's
+    /// `.well-known` document, followed by any added with
+    /// [`add_additional_issuers`](Self::add_additional_issuers).
+    ///
+    /// This is what [`can_handle_token`](Authenticator::can_handle_token) routes on, so a
+    /// caller assembling several authenticators can check here whether two of them would
+    /// compete for the same tokens.
+    #[must_use]
+    pub fn issuers(&self) -> &[String] {
+        &self.inner.issuers
+    }
+
+    /// The audiences this authenticator accepts; empty means any.
+    #[must_use]
+    pub fn audiences(&self) -> &[String] {
+        &self.inner.audiences
+    }
+
     /// Set the accepted audiences.
     /// If empty / not called, no audience validation is done.
     #[must_use]
@@ -447,13 +465,21 @@ fn authenticate_jwt(
             tracing::debug!(accepted_issuers = ?issuers, "Token issuer rejected: {e}");
             Error::rejected(RejectionReason::IssuerMismatch)
         }
-        jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(claim) if claim == "aud" => {
-            tracing::debug!(accepted_audiences = ?audiences, "Token audience rejected: {e}");
-            Error::rejected(RejectionReason::AudienceMismatch)
+        jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(claim) => {
+            Error::rejected(RejectionReason::ClaimMissing {
+                claim: claim.clone(),
+            })
         }
-        jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(claim) if claim == "iss" => {
-            tracing::debug!(accepted_issuers = ?issuers, "Token issuer rejected: {e}");
-            Error::rejected(RejectionReason::IssuerMismatch)
+        jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
+            Error::rejected(RejectionReason::Expired)
+        }
+        jsonwebtoken::errors::ErrorKind::ImmatureSignature => {
+            Error::rejected(RejectionReason::NotYetValid)
+        }
+        jsonwebtoken::errors::ErrorKind::InvalidClaimFormat(claim) => {
+            Error::rejected(RejectionReason::ClaimMalformed {
+                claim: claim.clone(),
+            })
         }
         _ => Error::JWTDecodeError {
             reason: format!("Failed to decode JWT token. {e}"),
@@ -900,6 +926,16 @@ mod test {
         (token, header)
     }
 
+    fn sign_without_exp(
+        key: &jsonwebtoken::EncodingKey,
+        claims: &serde_json::Value,
+    ) -> (String, Header) {
+        let mut header = Header::new(Algorithm::EdDSA);
+        header.kid = Some("k1".to_string());
+        let token = jsonwebtoken::encode(&header, claims, key).unwrap();
+        (token, header)
+    }
+
     const ISS: &str = "https://idp.example.com";
     const AUD: &str = "lakekeeper";
 
@@ -1020,14 +1056,6 @@ mod test {
     }
 
     #[test]
-    fn test_authenticate_jwt_rejects_token_without_aud_when_audience_configured() {
-        let (enc, jwk) = ed25519_fixture();
-        let (token, header) = sign(&enc, serde_json::json!({ "iss": ISS, "sub": "u" }));
-        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
-        assert_eq!(err.rejection(), Some(&RejectionReason::AudienceMismatch));
-    }
-
-    #[test]
     fn test_authenticate_jwt_accepts_token_without_aud_when_no_audience_configured() {
         let (enc, jwk) = ed25519_fixture();
         let (token, header) = sign(&enc, serde_json::json!({ "iss": ISS, "sub": "u" }));
@@ -1062,6 +1090,88 @@ mod test {
     }
 
     #[test]
+    fn test_authenticate_jwt_distinguishes_missing_from_mismatched_audience() {
+        let (enc, jwk) = ed25519_fixture();
+        let (token, header) = sign(&enc, serde_json::json!({ "iss": ISS, "sub": "u" }));
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(
+            err.rejection(),
+            Some(&RejectionReason::ClaimMissing {
+                claim: "aud".to_string()
+            })
+        );
+
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": "someone-else", "sub": "u" }),
+        );
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(err.rejection(), Some(&RejectionReason::AudienceMismatch));
+    }
+
+    #[test]
+    fn test_authenticate_jwt_expired_token_is_a_rejection() {
+        let (enc, jwk) = ed25519_fixture();
+        let mut header = Header::new(Algorithm::EdDSA);
+        header.kid = Some("k1".to_string());
+        let token = jsonwebtoken::encode(
+            &header,
+            &serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "exp": 1 }),
+            &enc,
+        )
+        .unwrap();
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(err.rejection(), Some(&RejectionReason::Expired));
+    }
+
+    #[test]
+    fn test_authenticate_jwt_not_yet_valid_token_is_a_rejection() {
+        let (enc, jwk) = ed25519_fixture();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let (token, header) = sign(
+            &enc,
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "nbf": now + 3600 }),
+        );
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(err.rejection(), Some(&RejectionReason::NotYetValid));
+    }
+
+    #[test]
+    fn test_authenticate_jwt_unusable_expiry_is_a_rejection() {
+        let (enc, jwk) = ed25519_fixture();
+        let mut header = Header::new(Algorithm::EdDSA);
+        header.kid = Some("k1".to_string());
+        let token = jsonwebtoken::encode(
+            &header,
+            &serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "exp": "soon" }),
+            &enc,
+        )
+        .unwrap();
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(
+            err.rejection(),
+            Some(&RejectionReason::ClaimMissing {
+                claim: "exp".to_string()
+            })
+        );
+        // A token with no expiry at all is rejected the same way.
+        let (token, header) = sign_without_exp(
+            &enc,
+            &serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u" }),
+        );
+        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
+        assert_eq!(
+            err.rejection(),
+            Some(&RejectionReason::ClaimMissing {
+                claim: "exp".to_string()
+            })
+        );
+    }
+
+    #[test]
     fn test_authenticate_jwt_bad_signature_is_not_a_rejection() {
         let (enc, _) = ed25519_fixture();
         let (_, other_jwk) = ed25519_fixture();
@@ -1077,23 +1187,37 @@ mod test {
         assert_eq!(err.rejection(), None);
     }
 
+    /// Time claims carry `jsonwebtoken`'s default 60 second leeway, which absorbs ordinary
+    /// clock drift between the issuer and this host. Pinned so a default change is visible.
     #[test]
-    fn test_authenticate_jwt_rejects_token_before_nbf() {
+    fn test_authenticate_jwt_tolerates_sixty_seconds_of_clock_drift() {
         let (enc, jwk) = ed25519_fixture();
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
+
+        // Not valid for another 30 s: within the leeway, accepted.
         let (token, header) = sign(
             &enc,
-            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "nbf": now + 3600 }),
+            serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "nbf": now + 30 }),
+        );
+        assert!(verify(&jwk, &token, &header, &[]).is_ok());
+
+        // Expired 30 s ago: within the leeway, accepted.
+        let (token, header) = sign_without_exp(
+            &enc,
+            &serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "exp": now - 30 }),
+        );
+        assert!(verify(&jwk, &token, &header, &[]).is_ok());
+
+        // Expired 10 min ago: beyond the leeway.
+        let (token, header) = sign_without_exp(
+            &enc,
+            &serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "exp": now - 600 }),
         );
         let err = verify(&jwk, &token, &header, &[]).unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Failed to decode JWT Token. Failed to decode JWT token. ImmatureSignature"
-        );
-        assert_eq!(err.rejection(), None);
+        assert_eq!(err.rejection(), Some(&RejectionReason::Expired));
     }
 
     #[test]
@@ -1132,25 +1256,6 @@ mod test {
         );
         let data = verify(&jwk, &token, &header, &[]).unwrap();
         assert_eq!(data.claims["sub"], "u");
-    }
-
-    #[test]
-    fn test_authenticate_jwt_expired_is_not_a_rejection() {
-        let (enc, jwk) = ed25519_fixture();
-        let mut header = Header::new(Algorithm::EdDSA);
-        header.kid = Some("k1".to_string());
-        let token = jsonwebtoken::encode(
-            &header,
-            &serde_json::json!({ "iss": ISS, "aud": AUD, "sub": "u", "exp": 1 }),
-            &enc,
-        )
-        .unwrap();
-        let err = verify(&jwk, &token, &header, &[]).unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Failed to decode JWT Token. Failed to decode JWT token. ExpiredSignature"
-        );
-        assert_eq!(err.rejection(), None);
     }
 
     // ---- scope sugar ----
@@ -1310,7 +1415,12 @@ mod test {
             .authenticate(&token, &crate::introspect::introspect(&token))
             .await
             .unwrap_err();
-        assert_eq!(err.rejection(), Some(&RejectionReason::AudienceMismatch));
+        assert_eq!(
+            err.rejection(),
+            Some(&RejectionReason::ClaimMissing {
+                claim: "aud".to_string()
+            })
+        );
 
         let (token, _) = sign(
             &enc,
@@ -1321,6 +1431,51 @@ mod test {
             .await
             .unwrap();
         assert_eq!(auth.subject().subject_in_idp(), "u");
+        server.abort();
+    }
+
+    /// The effective issuer list includes the issuer discovered from the provider's
+    /// `.well-known` document, which a caller cannot derive from its own configuration.
+    #[tokio::test]
+    async fn test_effective_issuers_and_audiences_are_readable() {
+        let (_, jwk) = ed25519_fixture();
+        let (issuer, server) = spawn_idp(jwks_for(&jwk)).await;
+        let authenticator = JWKSWebAuthenticator::new(&issuer, None)
+            .await
+            .unwrap()
+            .set_accepted_audiences(vec![AUD.to_string()])
+            .add_additional_issuers(vec!["https://sts.example.com".to_string()]);
+        assert_eq!(
+            authenticator.issuers(),
+            [issuer.clone(), "https://sts.example.com".to_string()]
+        );
+        assert_eq!(authenticator.audiences(), [AUD.to_string()]);
+        server.abort();
+    }
+
+    /// `limes` classifies an unknown key id by the message `jwks_client_rs` produces, so a
+    /// change to that message must fail here rather than silently reclassify the error.
+    #[tokio::test]
+    async fn test_unknown_key_id_is_an_authentication_failure() {
+        let (enc, jwk) = ed25519_fixture();
+        let (issuer, server) = spawn_idp(jwks_for(&jwk)).await;
+        let authenticator = JWKSWebAuthenticator::new(&issuer, None).await.unwrap();
+        let mut header = Header::new(Algorithm::EdDSA);
+        header.kid = Some("not-in-the-jwks".to_string());
+        let token = jsonwebtoken::encode(
+            &header,
+            &serde_json::json!({ "iss": issuer, "sub": "u", "exp": 9_999_999_999_i64 }),
+            &enc,
+        )
+        .unwrap();
+        let err = authenticator
+            .authenticate(&token, &crate::introspect::introspect(&token))
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Authentication failed: Token key id not found in JWKS."
+        );
         server.abort();
     }
 

--- a/crates/limes/src/jwks.rs
+++ b/crates/limes/src/jwks.rs
@@ -883,8 +883,12 @@ impl ScopeRule {
 
     /// Scopes are strings: a claim holding numbers or booleans is malformed and never
     /// satisfies the requirement, matching [`Authentication::scopes`].
+    ///
+    /// The guard reads the claim the rule itself resolved. Resolving it a second time would
+    /// let the guard vet one claim while the rule evaluates another.
     fn matches(&self, claims: &serde_json::Value) -> bool {
-        crate::authenticator::scope_claim(claims)
+        self.0
+            .resolve(claims)
             .and_then(crate::claims::strings)
             .is_some()
             && self.0.matches(claims)
@@ -1325,6 +1329,62 @@ mod test {
         let scope = ScopeRule::new("admin".to_string()).unwrap();
         assert!(!scope.matches(&serde_json::json!({ "scope": ["admin", 42] })));
         assert!(!scope.matches(&serde_json::json!({ "scope": ["admin", true] })));
+    }
+
+    /// The guard and the rule must read the same claim. When they resolve independently, a
+    /// `scope` that carries nothing sends the rule to `scp` while the guard still vets
+    /// `scope`, and a malformed `scp` passes unchecked.
+    #[test]
+    fn test_scope_rule_guards_the_claim_it_evaluates() {
+        let scope = ScopeRule::new("admin".to_string()).unwrap();
+        for empty in [
+            serde_json::json!(""),
+            serde_json::json!("   "),
+            serde_json::json!([]),
+            serde_json::json!([""]),
+            serde_json::json!({}),
+        ] {
+            for malformed in [
+                serde_json::json!(["admin", 42]),
+                serde_json::json!(["admin", true]),
+                serde_json::json!(["admin", null]),
+            ] {
+                let claims = serde_json::json!({ "scope": empty, "scp": malformed });
+                assert!(
+                    !scope.matches(&claims),
+                    "{claims} must not satisfy the scope"
+                );
+            }
+            // The same fallback with well-formed scopes does satisfy it.
+            let claims = serde_json::json!({ "scope": empty, "scp": ["admin"] });
+            assert!(scope.matches(&claims), "{claims} must satisfy the scope");
+        }
+    }
+
+    /// `Authentication::scopes` must report the scopes the requirement enforced against.
+    #[test]
+    fn test_reported_scopes_are_the_enforced_scopes() {
+        let scope = ScopeRule::new("admin".to_string()).unwrap();
+        for claims in [
+            serde_json::json!({ "scope": "", "scp": ["admin"] }),
+            serde_json::json!({ "scope": "   ", "scp": ["admin"] }),
+            serde_json::json!({ "scope": [], "scp": ["admin"] }),
+            serde_json::json!({ "scope": "admin", "scp": ["other"] }),
+        ] {
+            let auth = Authentication::builder()
+                .token_header(None)
+                .claims(claims.clone())
+                .name(None)
+                .email(None)
+                .subject(crate::Subject::new(None, "sub".to_string()))
+                .principal_type(None)
+                .build();
+            assert_eq!(
+                auth.scopes().any(|s| s == "admin"),
+                scope.matches(&claims),
+                "{claims}: reported scopes disagree with enforcement"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
A deny finds a banned value wherever it sits between delimiters, in any item,
so every way an issuer can join values is read. A grant splits a lone string
and leaves array elements whole.

One resolver picks the claim a set of paths names — the first populated path,
falling back to the first present one — ignoring the separator. The scope
requirement and `Authentication::scopes` read what it returns, so the string
guard vets the claim the requirement evaluates.

A claim carries content when it holds a value that is not blank, or, for an
object, a member. Values of a rule are not blank either, so a claim that
carries nothing holds nothing a rule could look for. A path containing `/` or
`:` names one claim and is looked up whole, so claims namespaced as URIs are
addressable.

`RejectionReason` gains `ClaimMissing`, `ClaimMalformed`, `Expired` and
`NotYetValid`, so a token rejected for its audience, issuer or lifetime is
distinguishable from one that never verified.
`JWKSWebAuthenticator::{issuers, audiences}` expose what token routing selects
on, including the issuer published by the discovery document.

A deny set is indexed at construction by the first byte of each value, so the
cost of a deny follows the length of the claim rather than the size of the set.

BREAKING CHANGE: `exists: true` requires a value that is not blank, and a rule
rejects a blank value. A separator splits only a lone string, and a rule with
fallback claims reads the first populated path. `ValueContainsSeparator` is
raised for `any_of` and `all_of` only. A missing `aud` or `iss` is
`ClaimMissing`, and an `exp` or `nbf` failure is `TokenRejected` rather than a
decode error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added access to accepted token issuers and audiences.
  - Improved authentication error details for missing or malformed claims, expired tokens, and tokens that are not yet valid.
  - Added validation for required issuer, audience, and expiration claims.

- **Bug Fixes**
  - Preserved array-based claim values without splitting them.
  - Improved fallback handling for scope claims.
  - Refined namespaced claim resolution and existence validation.
  - Strengthened separator, denial, Unicode, and multi-value claim matching.
  - Improved token time validation with clock-leeway support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->